### PR TITLE
refactor(application-prod): DBconnection time 조정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,7 +7,7 @@ spring:
     hikari:
       maximum-pool-size: 10
       minimum-idle: 5
-      connection-timeout: 20000
+      connection-timeout: 5000
       idle-timeout: 300000
       max-lifetime: 1200000
   jpa:


### PR DESCRIPTION
DBconnection time을 20초에서 5초로 줄였습니다.
DB연결시도가 5초가 넘을 시 실패로 처리합니다.
이제 트래픽이 몰릴때 더 안정적으로 동작합니다.