### PR TITLE
refactor: 조회시 DTO에서 객체 변환 책임 변경

### DIFF
--- a/src/main/java/com/starterpack/admin/member/AdminMemberController.java
+++ b/src/main/java/com/starterpack/admin/member/AdminMemberController.java
@@ -43,7 +43,11 @@ public class AdminMemberController {
         Sort sort = Sort.by(direction, sortBy);
         Pageable pageable = PageRequest.of(page, size, sort); // (현재 예제에선 페이징 직접 안 씀)
 
-        List<MemberResponseDto> members = memberService.findAllMembers();
+        List<Member> memberList = memberService.findAllMembers();
+
+        List<MemberResponseDto> members = memberList.stream()
+                .map(MemberResponseDto::new)
+                .toList();
 
         if (keyword != null && !keyword.trim().isEmpty()) {
             members = members.stream()

--- a/src/main/java/com/starterpack/admin/pack/AdminPackController.java
+++ b/src/main/java/com/starterpack/admin/pack/AdminPackController.java
@@ -3,7 +3,9 @@ package com.starterpack.admin.pack;
 import com.starterpack.category.service.CategoryService;
 import com.starterpack.pack.dto.PackCreateRequestDto;
 import com.starterpack.pack.dto.PackDetailResponseDto;
+import com.starterpack.pack.dto.PackResponseDto;
 import com.starterpack.pack.dto.PackUpdateRequestDto;
+import com.starterpack.pack.entity.Pack;
 import com.starterpack.pack.service.PackService;
 import com.starterpack.product.service.ProductService;
 import jakarta.validation.Valid;
@@ -29,7 +31,13 @@ public class AdminPackController {
     @GetMapping
     public String listAll(Model model){
         model.addAttribute("categories", categoryService.findAllCategories());
-        model.addAttribute("packs", packService.getPacks());
+
+        List<Pack> packList = packService.getPacks();
+        List<PackResponseDto> packs = packList.stream()
+                .map(PackResponseDto::from)
+                .toList();
+
+        model.addAttribute("packs", packs);
         return "admin/packs/list";
     }
 

--- a/src/main/java/com/starterpack/member/controller/MemberController.java
+++ b/src/main/java/com/starterpack/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.starterpack.member.controller;
 import com.starterpack.auth.service.AuthService;
 import com.starterpack.member.dto.MemberResponseDto;
 import com.starterpack.member.dto.MemberUpdateRequestDto;
+import com.starterpack.member.entity.Member;
 import com.starterpack.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -30,8 +31,13 @@ public class MemberController {
     @Operation(summary = "회원 목록 조회", description = "모든 회원 목록을 조회합니다.")
     @SecurityRequirement(name = "Bearer Authentication")
     public ResponseEntity<List<MemberResponseDto>> getAllMembers() {
-        List<MemberResponseDto> members = memberService.findAllMembers();
-        return ResponseEntity.status(HttpStatus.OK).body(members);
+        List<Member> members = memberService.findAllMembers();
+
+        List<MemberResponseDto> responseDto = members.stream()
+                .map(MemberResponseDto::new)
+                .toList();
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
     @GetMapping("/{userId}")

--- a/src/main/java/com/starterpack/member/service/MemberService.java
+++ b/src/main/java/com/starterpack/member/service/MemberService.java
@@ -26,10 +26,8 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
 
     // 모든 멤버 조회
-    public List<MemberResponseDto> findAllMembers() {
-        return memberRepository.findAll().stream()
-                .map(MemberResponseDto::new)
-                .collect(Collectors.toList());
+    public List<Member> findAllMembers() {
+        return memberRepository.findAll();
     }
 
     // ID로 멤버 조회

--- a/src/main/java/com/starterpack/pack/controller/PackController.java
+++ b/src/main/java/com/starterpack/pack/controller/PackController.java
@@ -4,6 +4,7 @@ import com.starterpack.pack.dto.PackCreateRequestDto;
 import com.starterpack.pack.dto.PackDetailResponseDto;
 import com.starterpack.pack.dto.PackResponseDto;
 import com.starterpack.pack.dto.PackUpdateRequestDto;
+import com.starterpack.pack.entity.Pack;
 import com.starterpack.pack.service.PackService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -30,7 +31,13 @@ public class PackController {
     @GetMapping("/packs")
     @Operation(summary = "스타터팩 목록 조회", description = "모든 스타터팩 목록을 조회합니다.")
     public Map<String, List<PackResponseDto>> getAllPacks() {
-        return Map.of("packs", packService.getPacks());
+        List<Pack> packs = packService.getPacks();
+
+        List<PackResponseDto> responseDto = packs.stream()
+                .map(PackResponseDto::from)
+                .toList();
+
+        return Map.of("packs", responseDto);
     }
 
     @GetMapping("/categories/{categoryId}/packs")

--- a/src/main/java/com/starterpack/pack/service/PackService.java
+++ b/src/main/java/com/starterpack/pack/service/PackService.java
@@ -27,10 +27,8 @@ public class PackService {
     private final ProductRepository productRepository;
 
     @Transactional(readOnly = true)
-    public List<PackResponseDto> getPacks() {
-        return packRepository.findAll().stream()
-                .map(PackResponseDto::from)
-                .toList();
+    public List<Pack> getPacks() {
+        return packRepository.findAll();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
- pack과 member에서 전체 조회할 때 서비스 계층에서 엔티티 -> Dto 변환을 수행했는데 이를 컨트롤러에서 수행하도록 변경했습니다
- product도 해야하는데 충돌 방지를 위해서 PR 끊어서 날리겠습니다.