### PR TITLE
refactor: 엔티티<->dto 변환을 FeedController 로 옮김

### DIFF
--- a/src/main/java/com/starterpack/feed/controller/FeedController.java
+++ b/src/main/java/com/starterpack/feed/controller/FeedController.java
@@ -4,6 +4,7 @@ import com.starterpack.auth.CustomMemberDetails;
 import com.starterpack.feed.dto.FeedCreateRequestDto;
 import com.starterpack.feed.dto.FeedResponseDto;
 import com.starterpack.feed.dto.FeedUpdateRequestDto;
+import com.starterpack.feed.entity.Feed;
 import com.starterpack.feed.service.FeedService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,20 +36,29 @@ public class FeedController {
             @AuthenticationPrincipal CustomMemberDetails customMemberDetails,
             @RequestBody FeedCreateRequestDto feedCreateDto
     ) {
-        FeedResponseDto responseDto = feedService.addFeed(customMemberDetails.getMember(), feedCreateDto);
+        Feed feed = feedService.addFeed(customMemberDetails.getMember(), feedCreateDto);
+
+        FeedResponseDto responseDto = FeedResponseDto.from(feed);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
     @GetMapping("/{feedId}")
     public ResponseEntity<FeedResponseDto> getFeed (@PathVariable Long feedId) {
-        FeedResponseDto responseDto = feedService.getFeed(feedId);
+        Feed feed = feedService.getFeed(feedId);
+
+        FeedResponseDto responseDto = FeedResponseDto.from(feed);
+
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
     @GetMapping
     public ResponseEntity<Page<FeedResponseDto>> getAllFeeds(
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<FeedResponseDto> responseDto = feedService.getAllFeeds(pageable);
+        Page<Feed> feedPage = feedService.getAllFeeds(pageable);
+
+        Page<FeedResponseDto> responseDto = feedPage.map(FeedResponseDto::from);
+
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
@@ -58,7 +68,10 @@ public class FeedController {
             @AuthenticationPrincipal CustomMemberDetails customMemberDetails,
             @RequestBody FeedUpdateRequestDto feedUpdateRequestDto
     ) {
-        FeedResponseDto responseDto = feedService.updateFeed(feedId, customMemberDetails.getMember(), feedUpdateRequestDto);
+        Feed feed = feedService.updateFeed(feedId, customMemberDetails.getMember(), feedUpdateRequestDto);
+
+        FeedResponseDto responseDto = FeedResponseDto.from(feed);
+
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 

--- a/src/main/java/com/starterpack/feed/service/FeedService.java
+++ b/src/main/java/com/starterpack/feed/service/FeedService.java
@@ -29,7 +29,7 @@ public class FeedService {
     private final ProductRepository productRepository;
 
     @Transactional
-    public FeedResponseDto addFeed(
+    public Feed addFeed(
             Member member,
             FeedCreateRequestDto createDto) {
         Category category = getCategory(createDto.categoryId());
@@ -46,25 +46,21 @@ public class FeedService {
             createDto.products().forEach(productDto -> addProductToFeed(feed, productDto));
         }
 
-        return FeedResponseDto.from(feedRepository.save(feed));
+        return feedRepository.save(feed);
     }
 
     @Transactional(readOnly = true)
-    public FeedResponseDto getFeed(Long feedId) {
-        Feed feed = getFeedByIdWithDetails(feedId);
-
-        return FeedResponseDto.from(feed);
+    public Feed getFeed(Long feedId) {
+        return getFeedByIdWithDetails(feedId);
     }
 
     @Transactional(readOnly = true)
-    public Page<FeedResponseDto> getAllFeeds(Pageable pageable) {
-        Page<Feed> feedPage = feedRepository.findAll(pageable);
-
-        return feedPage.map(FeedResponseDto::from);
+    public Page<Feed> getAllFeeds(Pageable pageable) {
+        return feedRepository.findAll(pageable);
     }
 
     @Transactional
-    public FeedResponseDto updateFeed(
+    public Feed updateFeed(
             Long feedId,
             Member member,
             FeedUpdateRequestDto updateDto
@@ -79,7 +75,7 @@ public class FeedService {
                 updateDto.imageUrl(),
                 category);
 
-        return FeedResponseDto.from(feed);
+        return feed;
     }
 
     @Transactional


### PR DESCRIPTION
### 수정 사항
1. 엔티티 <-> dto 변환을 FeedController가 하도록 하였습니다.