### PR TITLE
Sanghyeon1225/jwt cookie

### DIFF
--- a/src/main/java/com/starterpack/admin/login/AdminLoginController.java
+++ b/src/main/java/com/starterpack/admin/login/AdminLoginController.java
@@ -6,6 +6,8 @@ import com.starterpack.auth.service.AuthService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,12 +41,15 @@ public class AdminLoginController {
             LocalLoginRequestDto loginRequestDto = new LocalLoginRequestDto(email, password);
             TokenResponseDto tokenResponseDto = authService.localLogin(loginRequestDto);
 
-            Cookie cookie = new Cookie("jwt_token", tokenResponseDto.accessToken());
-            cookie.setHttpOnly(true);
-            cookie.setSecure(true);
-            cookie.setPath("/");
-            cookie.setMaxAge(60 * 60);
-            response.addCookie(cookie);
+            ResponseCookie cookie = ResponseCookie.from("jwt_token", tokenResponseDto.accessToken())
+                    .httpOnly(true)
+                    .secure(true)
+                    .path("/")
+                    .maxAge(60 * 60)
+                    .sameSite("Lax")
+                    .build();
+
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
             return "redirect:/admin/members";
         } catch (Exception e) {

--- a/src/main/java/com/starterpack/auth/controller/AuthController.java
+++ b/src/main/java/com/starterpack/auth/controller/AuthController.java
@@ -5,9 +5,12 @@ import com.starterpack.auth.dto.TokenResponseDto;
 import com.starterpack.auth.service.AuthService;
 import com.starterpack.auth.dto.LocalSignUpRequestDto;
 import com.starterpack.member.dto.MemberResponseDto;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,11 +39,25 @@ public class AuthController {
      * 로컬 로그인 API
      */
     @PostMapping("/login")
-    public ResponseEntity<TokenResponseDto> localLogin(
-            @Valid @RequestBody LocalLoginRequestDto requestDto
+    public ResponseEntity<Void> localLogin(
+            @Valid @RequestBody LocalLoginRequestDto requestDto,
+            HttpServletResponse  response
     ) {
         TokenResponseDto tokenResponseDto = authService.localLogin(requestDto);
-        return ResponseEntity.ok(tokenResponseDto);
+        String accessToken = tokenResponseDto.accessToken();
+
+        ResponseCookie cookie = ResponseCookie.from("jwt_token", accessToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(60 * 60) // 1시간
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ResponseEntity.ok().build();
+
     }
 
 }

--- a/src/main/java/com/starterpack/config/SecurityConfig.java
+++ b/src/main/java/com/starterpack/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.HttpMethod;
 
 @Configuration
 @EnableWebSecurity
@@ -68,6 +69,9 @@ public class SecurityConfig {
         // API 엔드포인트별 접근 권한 설정
         http.authorizeHttpRequests(auth -> auth
                         //.requestMatchers("/**").permitAll() // 개발 단계에선 이것만 주석 해제하고 아래는 주석 처리
+                        .requestMatchers(HttpMethod.GET, "/api/feeds", "/api/feeds/**", // feed 관련 GET 요청
+                        "/api/starterPack/packs", "/api/starterPack/packs/**", "/api/api/starterPack/categories/**", // starterpack 관련 GET 요청
+                        "/api/products", "/api/products/**").permitAll() // products 관련 GET 요청
                         .requestMatchers(PUBLIC_URLS).permitAll() // 배포 환경에선 아래 둘 주석 해제하기
                         .anyRequest().authenticated()
         );


### PR DESCRIPTION
### 📌 PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### ✈️ 반영 브랜치
sanghyeon1225/jwtCookie

### 📄 관련 이슈
<!-- 이슈번호: #62 -->

### 🧑‍💻 구현한 내용
- JWT 발급 방식을 HttpOnly쿠키를 통하도록 변경
- GET 요청 같이 JWT 토큰이 필요 없는 요청은 인증 인가가 수행되지 않도록 Security Config 수정 (상품 목록 조회, 스타터팩 목록 조회, 피드 목록 조회까지 추가됨)
- 승원님이 발견한 사파리에서 관리자 페이지를 통한 로그인을 해도 정상 접근이 안되는 현상 수정 (아마 Samesite 설정이 쿠키에 안되어있어서 그런거 같은데 설정 추가했습니다. 혹시나 안되면 말씀해주세요)

### 🧪 테스트 결과
상품 조회는 쿠키가 없어도 정상 수행됨
<img width="1656" height="1163" alt="image" src="https://github.com/user-attachments/assets/b88b7a3a-05a4-4853-8f34-b8f2a9a791bf" />



상품 추가는 쿠키가 없으면 수행이 안됨
<img width="1675" height="945" alt="image" src="https://github.com/user-attachments/assets/d12f2843-fbae-4703-9b05-3a9d1d9c1124" />


### 👿 트러블 슈팅

### 💬 코멘트
- 혹시나 API 중에 인증 인가 안해도 되는 API가 있는데 제가 빼먹은게 있으면 말해주시면 감사하겠습니다 !!


