### PR TITLE
feat: 프론트 배포 서버 CORS 추가

### DIFF
--- a/src/main/java/com/starterpack/config/SecurityConfig.java
+++ b/src/main/java/com/starterpack/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -65,6 +66,8 @@ public class SecurityConfig {
         // 폼 로그인 및 HTTP Basic 인증 비활성화
         http.formLogin(form -> form.disable());
         http.httpBasic(basic -> basic.disable());
+
+        http.cors(Customizer.withDefaults());
 
         // API 엔드포인트별 접근 권한 설정
         http.authorizeHttpRequests(auth -> auth

--- a/src/main/java/com/starterpack/config/WebConfig.java
+++ b/src/main/java/com/starterpack/config/WebConfig.java
@@ -22,7 +22,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173", "https://team17be-production.up.railway.app")
+                .allowedOrigins("http://localhost:5173", "https://localhost:5173", "https://team17be-production.up.railway.app", "https://team-17-fe-theta.vercel.app")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)


### PR DESCRIPTION
### 📌 PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
sanghyeon1225/CORS -> develop

### 📄 관련 이슈

### 🧑‍💻 구현한 내용
- WebConfig의 CORS 설정에 프론트엔드 배포 서버 주소 추가
- SecurityConfig의 securityFilterChain에 CORS 연결 코드 추가

### 🧪 테스트 결과

### 👿 트러블 슈팅

### 💬 코멘트



