### PR TITLE
feat: 로그인 없이 관리자 페이지 접근시 관리자페이지 로그인 페이지로 리다이렉트 (#69)

### DIFF
--- a/src/main/java/com/starterpack/admin/login/AdminLoginController.java
+++ b/src/main/java/com/starterpack/admin/login/AdminLoginController.java
@@ -3,7 +3,6 @@ package com.starterpack.admin.login;
 import com.starterpack.auth.dto.LocalLoginRequestDto;
 import com.starterpack.auth.dto.TokenResponseDto;
 import com.starterpack.auth.service.AuthService;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -19,13 +18,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequiredArgsConstructor
 public class AdminLoginController {
     private final AuthService authService;
+    
 
     /**
      * 관리자 로그인 페이지를 보여주는 메서드
      */
     @GetMapping("/login")
     public String showLoginPage() {
-        return "admin/login"; //
+        return "admin/login";
     }
 
     /**
@@ -51,7 +51,8 @@ public class AdminLoginController {
 
             response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
-            return "redirect:/admin/members";
+            // 로그인 성공 시 스타터팩 관리 페이지로 리다이렉션
+            return "redirect:/admin/packs";
         } catch (Exception e) {
             return "redirect:/admin/login?error=true";
         }

--- a/src/main/java/com/starterpack/auth/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/starterpack/auth/exception/CustomAuthenticationEntryPoint.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * Spring Security의 인증 실패(401 UNAUTHORIZED)를 처리하는 커스텀 핸들러
+ * 관리자 페이지(/admin/로 시작하는 URL)로 접근하면 관리자 로그인 페이지로 리다이렉션
  */
 @Slf4j
 @Component
@@ -27,6 +28,14 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             throws IOException, ServletException{
         log.warn("인증되지 않은 사용자 접근: {}", request.getRequestURI(), authException);
 
+        // 관리자 페이지 URL인지 확인
+        if (request.getRequestURI().startsWith("/admin/")) {
+            // 관리자 페이지 URL이면 관리자 로그인 페이지로 리다이렉션
+            response.sendRedirect("/admin/login");
+            return;
+        }
+
+        // API 요청에 대해서는 JSON 응답 반환
         final ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.UNAUTHORIZED);
 
         response.setStatus(ErrorCode.UNAUTHORIZED.getHttpStatus().value());


### PR DESCRIPTION
### 📌 PR 타입
-[ ✅] 기능 추가
-[ ] 기능 삭제
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--lee-seung-won/adminPageRedirect -> dev-->

### 📄 관련 이슈
<!-- 이슈번호: #69 -->

### 🧑‍💻 구현한 내용
이제 관리자페이지에 로그인 없이 접근 시 로그인 페이지로 리다이렉트 됩니다.
- 일단 로그인 시 스타터팩 관리자 페이지로 리다이렉트되게 설정하였습니다.
- 후에 홈화면을 구현하여 홈화면으로 가도록 하면 될 것 같습니다.

### 🧪 테스트 결과
정상적으로 작동합니다

### 👿 트러블 슈팅

### 💬 코멘트



