### PR TITLE
refactor: 메모리 사용량 최적화

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,19 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
     CMD curl -f http://localhost:8080/actuator/health || exit 1
 
-# 애플리케이션 실행 (Railway 호환)
-ENTRYPOINT ["java","-Xmx512m","-Xms256m","-XX:+UseG1GC","-XX:+UseContainerSupport","-XX:MaxRAMPercentage=75.0","-jar","app.jar"]
+# 애플리케이션 실행 (Railway 호환 - 메모리 최적화)
+ENTRYPOINT ["java", \
+    "-Xmx384m", \
+    "-Xms128m", \
+    "-XX:+UseG1GC", \
+    "-XX:+UseContainerSupport", \
+    "-XX:MaxRAMPercentage=60.0", \
+    "-XX:G1HeapRegionSize=16m", \
+    "-XX:MaxGCPauseMillis=200", \
+    "-XX:+UseStringDeduplication", \
+    "-XX:+OptimizeStringConcat", \
+    "-XX:+TieredCompilation", \
+    "-XX:TieredStopAtLevel=1", \
+    "-Djava.security.egd=file:/dev/./urandom", \
+    "-Dspring.profiles.active=prod", \
+    "-jar","app.jar"]

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,23 +5,30 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     hikari:
-      maximum-pool-size: 10
-      minimum-idle: 5
-      connection-timeout: 5000
-      idle-timeout: 300000
-      max-lifetime: 1200000
+      maximum-pool-size: 5
+      minimum-idle: 2
+      connection-timeout: 3000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      leak-detection-threshold: 60000
   jpa:
     hibernate:
       ddl-auto: update
     show-sql: false
     properties:
-      hibernate:
+        hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: false
         jdbc:
-          batch_size: 20
+          batch_size: 25
+          fetch_size: 50
         order_inserts: true
         order_updates: true
+        cache:
+          use_second_level_cache: false
+          use_query_cache: false
+        connection:
+          provider_disables_autocommit: true
   sql:
     init:
       mode: never
@@ -33,7 +40,14 @@ server:
   compression:
     enabled: true
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json
-    min-response-size: 1024
+    min-response-size: 512
+  tomcat:
+    threads:
+      max: 50
+      min-spare: 5
+    connection-timeout: 20000
+    max-connections: 8192
+    accept-count: 100
 
 logging:
   level:


### PR DESCRIPTION
### 📌 PR 타입
-[ ] 기능 추가
-[ ] 기능 삭제
-[ ] 버그 수정
-[ ✅ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--lee-seung-won/downgradeServerForDecreaseUsage -> dev-->

### 📄 관련 이슈
<!-- 이슈번호:  -->

### 🧑‍💻 구현한 내용
서버비 절감을 위해 JVM설정을 최적화하였습니다.

- **Dockerfile최적화**
- 힙 메모리: 512MB → 384MB
- 초기 메모리: 256MB → 128MB
- 최대 RAM 비율: 75% → 60%
- GC 최적화: G1GC 세부 설정 추가
- 컴파일 최적화: TieredCompilation 설정
- **데이터베이스 연결 풀 최적화**
- 최대 연결 수: 10개 → 5개
- 최소 유휴 연결: 5개 → 2개
- 연결 유지 시간: 20분 → 30분
- 누수 감지: 60초로 설정
- **Hibernate 최적화**
- 배치 크기: 20 → 25
- 페치 크기: 50 추가
- 캐시 비활성화: 2차 캐시, 쿼리 캐시 비활성화
- 자동 커밋 비활성화: 성능 향상
- **서버 설정 최적화**
- 압축 최소 크기: 1024B → 512B
- Tomcat 스레드: 최대 50개, 최소 5개
- 연결 타임아웃: 20초

### 🧪 테스트 결과
평상 시 603MB의 메모리를 사용하고 있었습니다.
최적화 적용 후 315MB로 줄었습니다.

최적화 적용전
<img width="373" height="339" alt="스크린샷 2025-10-03 오전 10 31 30" src="https://github.com/user-attachments/assets/f17e3b4a-89c8-4dca-bb6d-a73308bcaa0e" />

최적화 적용 후
<img width="361" height="348" alt="스크린샷 2025-10-03 오전 10 53 34" src="https://github.com/user-attachments/assets/02e751c9-7321-43ba-b8ef-d3c6eddc1c26" />


### 👿 트러블 슈팅

### 💬 코멘트
트랙픽이 거의 발생하지 않는 개발단계에 맞게 설정한 것이므로,
후에 사용자 테스트를 위해 배포할 시에는 다시 그에 맞게 변경해야 합니다.


