### PR TITLE
refactor: LinkModerationService HTML 태그 제거 로직에 Apache Commons Text 라이…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+	implementation 'org.apache.commons:commons-text:1.12.0'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/starterpack/linkpolicy/service/LinkModerationServiceTest.java
+++ b/src/test/java/com/starterpack/linkpolicy/service/LinkModerationServiceTest.java
@@ -37,7 +37,7 @@ class LinkModerationServiceTest {
     }
 
     @Test
-    @DisplayName("HTML 태그 제거 테스트")
+    @DisplayName("HTML 태그 제거 테스트 - Apache Commons Text 적용")
     void sanitizeHtmlFromUrl() {
         // Given
         String urlWithHtml = "https://example.com<script>alert('xss')</script>";
@@ -250,6 +250,41 @@ class LinkModerationServiceTest {
 
         // Then
         assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("Apache Commons Text - HTML 엔티티 디코딩 테스트")
+    void sanitizeHtmlFromUrl_HtmlEntities() {
+        // Given
+        String urlWithHtmlEntities = "https://example.com&amp;param=value&lt;script&gt;";
+
+        // When
+        String result = linkModerationService.sanitizeHtmlFromUrl(urlWithHtmlEntities);
+
+        // Then - HTML 엔티티 디코딩 후 스크립트 태그가 제거됨
+        assertThat(result).isEqualTo("https://example.com&param=value");
+    }
+
+    @Test
+    @DisplayName("Apache Commons Text - null/blank 처리 테스트")
+    void sanitizeHtmlFromUrl_NullAndBlank() {
+        // Given & When & Then
+        assertThat(linkModerationService.sanitizeHtmlFromUrl(null)).isNull();
+        assertThat(linkModerationService.sanitizeHtmlFromUrl("")).isNull();
+        assertThat(linkModerationService.sanitizeHtmlFromUrl("   ")).isNull();
+    }
+
+    @Test
+    @DisplayName("Apache Commons Text - 공백 처리 테스트")
+    void validateUrlByRegex_SpacesHandling() {
+        // Given
+        String urlWithSpaces = "  https://example.com  ";
+
+        // When
+        boolean result = linkModerationService.validateUrlByRegex(urlWithSpaces);
+
+        // Then
+        assertThat(result).isTrue();
     }
 
     @Test


### PR DESCRIPTION
…브러리 적용

### 📌 PR 타입
-[✅ ] 기능 추가
-[ ] 기능 삭제
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--lee-seung-won/applyApacheCommonsTextToLinkModerationService-> dev-->

### 📄 관련 이슈
<!-- 이슈번호:  -->

### 🧑‍💻 구현한 내용
멘토님 피드백을 반영하여 기존에 raw하게 짜여있던 html태그 제거 로직을 
ApacheCommonsText라이브러리를 사용하는 것으로 변경하였습니다.
<img width="573" height="404" alt="image" src="https://github.com/user-attachments/assets/45ce2477-6797-4237-a6aa-0df894468e80" />

### 🧪 테스트 결과
기존에 있던 테스트 로직에 몇가지 검증과정을 추가하였습니다.
23개의 테스트 모두 성공적으로 통과하였습니다.
<img width="323" height="161" alt="image" src="https://github.com/user-attachments/assets/eaa08280-95bf-4b04-89cd-22027d65d2f9" />


### 👿 트러블 슈팅

### 💬 코멘트



