### PR TITLE
Lee seung won/mypage api

### DIFF
--- a/src/main/java/com/starterpack/config/SecurityConfig.java
+++ b/src/main/java/com/starterpack/config/SecurityConfig.java
@@ -109,7 +109,8 @@ public class SecurityConfig {
                                 "/api/products", "/api/products/**",
                                 "/api/categories", // 카테고리 조회 GET 요청
                                 "/api/feeds/*/likes",
-                                "/api/starterPack/packs/*/likes"
+                                "/api/starterPack/packs/*/likes",
+                                "/api/members/*/mypage" // 마이페이지 조회
                         ).permitAll()
                         .requestMatchers(API_PUBLIC_URLS).permitAll()
                         .requestMatchers(COMMON_PUBLIC_URLS).permitAll()
@@ -117,7 +118,8 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(
                         new JwtTokenFilter(userDetailsService, jwtTokenUtil,
-                                Stream.of(API_PUBLIC_URLS, COMMON_PUBLIC_URLS).flatMap(Stream::of).toList(),
+                                Stream.of(API_PUBLIC_URLS, COMMON_PUBLIC_URLS, 
+                                         new String[]{"/api/members/*/mypage"}).flatMap(Stream::of).toList(),
                                 jwtTokenResolver),
                         UsernamePasswordAuthenticationFilter.class
                 )

--- a/src/main/java/com/starterpack/config/SecurityConfig.java
+++ b/src/main/java/com/starterpack/config/SecurityConfig.java
@@ -118,8 +118,7 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(
                         new JwtTokenFilter(userDetailsService, jwtTokenUtil,
-                                Stream.of(API_PUBLIC_URLS, COMMON_PUBLIC_URLS, 
-                                         new String[]{"/api/members/*/mypage"}).flatMap(Stream::of).toList(),
+                                Stream.of(API_PUBLIC_URLS, COMMON_PUBLIC_URLS).flatMap(Stream::of).toList(),
                                 jwtTokenResolver),
                         UsernamePasswordAuthenticationFilter.class
                 )

--- a/src/main/java/com/starterpack/feed/repository/FeedRepository.java
+++ b/src/main/java/com/starterpack/feed/repository/FeedRepository.java
@@ -48,4 +48,13 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, JpaSpecificat
     @Modifying
     @Query("UPDATE Feed f SET f.commentCount = f.commentCount - 1 WHERE f.id = :feedId AND f.commentCount > 0")
     void decrementCommentCount(@Param("feedId") Long id);
+
+    // 멤버별 피드 목록 조회
+    @EntityGraph(attributePaths = {"user", "category"})
+    @Query("select f from Feed f where f.user.userId = :memberId order by f.id desc")
+    Page<Feed> findByUserId(@Param("memberId") Long memberId, Pageable pageable);
+
+    // 멤버별 피드 개수 조회
+    @Query("select count(f) from Feed f where f.user.userId = :memberId")
+    long countByUserId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/starterpack/member/controller/MemberController.java
+++ b/src/main/java/com/starterpack/member/controller/MemberController.java
@@ -1,10 +1,8 @@
 package com.starterpack.member.controller;
 
 import com.starterpack.auth.service.AuthService;
-import com.starterpack.auth.login.Login;
 import com.starterpack.member.dto.MemberResponseDto;
 import com.starterpack.member.dto.MemberUpdateRequestDto;
-import com.starterpack.member.dto.MyPageResponseDto;
 import com.starterpack.member.entity.Member;
 import com.starterpack.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -101,18 +99,6 @@ public class MemberController {
             @RequestParam Boolean isActive
     ) {
         MemberResponseDto responseDto = memberService.updateMemberActiveStatus(userId, isActive);
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
-    }
-
-    @GetMapping("/{userId}/mypage")
-    @Operation(summary = "마이페이지 조회", description = "특정 회원의 마이페이지 정보를 조회합니다.")
-    @SecurityRequirement(name = "Bearer Authentication")
-    public ResponseEntity<MyPageResponseDto> getMyPage(
-            @PathVariable Long userId,
-            @Login(required = false) Member currentMember
-    ) {
-        Long currentUserId = (currentMember != null) ? currentMember.getUserId() : null;
-        MyPageResponseDto responseDto = memberService.getMyPage(userId, currentUserId);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 }

--- a/src/main/java/com/starterpack/member/controller/MemberController.java
+++ b/src/main/java/com/starterpack/member/controller/MemberController.java
@@ -1,8 +1,10 @@
 package com.starterpack.member.controller;
 
 import com.starterpack.auth.service.AuthService;
+import com.starterpack.auth.login.Login;
 import com.starterpack.member.dto.MemberResponseDto;
 import com.starterpack.member.dto.MemberUpdateRequestDto;
+import com.starterpack.member.dto.MyPageResponseDto;
 import com.starterpack.member.entity.Member;
 import com.starterpack.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -99,6 +101,18 @@ public class MemberController {
             @RequestParam Boolean isActive
     ) {
         MemberResponseDto responseDto = memberService.updateMemberActiveStatus(userId, isActive);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
+    @GetMapping("/{userId}/mypage")
+    @Operation(summary = "마이페이지 조회", description = "특정 회원의 마이페이지 정보를 조회합니다.")
+    @SecurityRequirement(name = "Bearer Authentication")
+    public ResponseEntity<MyPageResponseDto> getMyPage(
+            @PathVariable Long userId,
+            @Login(required = false) Member currentMember
+    ) {
+        Long currentUserId = (currentMember != null) ? currentMember.getUserId() : null;
+        MyPageResponseDto responseDto = memberService.getMyPage(userId, currentUserId);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 }

--- a/src/main/java/com/starterpack/member/controller/MyPageController.java
+++ b/src/main/java/com/starterpack/member/controller/MyPageController.java
@@ -1,0 +1,72 @@
+package com.starterpack.member.controller;
+
+import com.starterpack.auth.login.Login;
+import com.starterpack.member.dto.MyPageResponseDto;
+import com.starterpack.member.entity.Member;
+import com.starterpack.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/members")
+@Tag(name = "MyPage", description = "마이페이지 API")
+public class MyPageController {
+    private final MemberService memberService;
+
+    public MyPageController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @GetMapping("/{userId}/mypage")
+    @Operation(
+            summary = "마이페이지 조회", 
+            description = """
+                    특정 회원의 마이페이지 정보를 조회합니다.
+                    
+                    **인증**: 비로그인 사용자도 조회 가능 (토큰 없이도 요청 가능)
+                    
+                    **응답 정보**:
+                    - 사용자 기본 정보 (닉네임, 프로필 이미지, 취미, 한 줄 소개)
+                    - 게시물 통계 (팩 개수, 피드 개수, 전체 게시물 수)
+                    - 작성한 팩 목록 (최신순, 제목, 이미지)
+                    - 작성한 피드 목록 (최신순, 설명, 이미지)
+                    - isMe: 조회한 사람이 본인인지 여부 (로그인 필수)
+                    
+                    **예시**:
+                    - 비로그인 사용자가 조회: isMe = false
+                    - 다른 사용자가 조회: isMe = false
+                    - 본인이 조회: isMe = true
+                    """
+    )
+    @Parameter(
+            name = "userId", 
+            description = "조회할 회원의 ID",
+            required = true,
+            example = "1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", 
+                    description = "마이페이지 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404", 
+                    description = "회원을 찾을 수 없음"
+            )
+    })
+    public ResponseEntity<MyPageResponseDto> getMyPage(
+            @PathVariable Long userId,
+            @Login(required = false) Member currentMember
+    ) {
+        Long currentUserId = (currentMember != null) ? currentMember.getUserId() : null;
+        MyPageResponseDto responseDto = memberService.getMyPage(userId, currentUserId);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+}
+

--- a/src/main/java/com/starterpack/member/dto/MyPageFeedDto.java
+++ b/src/main/java/com/starterpack/member/dto/MyPageFeedDto.java
@@ -1,0 +1,19 @@
+package com.starterpack.member.dto;
+
+import com.starterpack.feed.entity.Feed;
+
+// 마이페이지에서 사용할 간단한 피드 정보
+public record MyPageFeedDto(
+        Long feedId,
+        String description,
+        String imageUrl
+) {
+    public static MyPageFeedDto from(Feed feed) {
+        return new MyPageFeedDto(
+                feed.getId(),
+                feed.getDescription(),
+                feed.getImageUrl()
+        );
+    }
+}
+

--- a/src/main/java/com/starterpack/member/dto/MyPagePackDto.java
+++ b/src/main/java/com/starterpack/member/dto/MyPagePackDto.java
@@ -1,0 +1,19 @@
+package com.starterpack.member.dto;
+
+import com.starterpack.pack.entity.Pack;
+
+// 마이페이지에서 사용할 간단한 팩 정보
+public record MyPagePackDto(
+        Long packId,
+        String name,
+        String mainImageUrl
+) {
+    public static MyPagePackDto from(Pack pack) {
+        return new MyPagePackDto(
+                pack.getId(),
+                pack.getName(),
+                pack.getMainImageUrl()
+        );
+    }
+}
+

--- a/src/main/java/com/starterpack/member/dto/MyPageResponseDto.java
+++ b/src/main/java/com/starterpack/member/dto/MyPageResponseDto.java
@@ -1,0 +1,46 @@
+package com.starterpack.member.dto;
+
+import com.starterpack.member.entity.Member;
+import com.starterpack.pack.entity.Pack;
+import com.starterpack.feed.entity.Feed;
+import java.util.List;
+
+// 마이페이지 응답 DTO
+public record MyPageResponseDto(
+        String nickname,
+        String hobby,
+        String profileImageUrl,
+        String bio,
+        long totalPostCount,
+        long packCount,
+        long feedCount,
+        List<MyPagePackDto> packs,
+        List<MyPageFeedDto> feeds,
+        boolean isMe
+) {
+    public static MyPageResponseDto from(Member member, List<Pack> packs, List<Feed> feeds, boolean isMe) {
+        List<MyPagePackDto> packDtos = packs.stream()
+                .map(MyPagePackDto::from)
+                .toList();
+        
+        List<MyPageFeedDto> feedDtos = feeds.stream()
+                .map(MyPageFeedDto::from)
+                .toList();
+        
+        long totalPostCount = packs.size() + feeds.size();
+        
+        return new MyPageResponseDto(
+                member.getNickname(),
+                member.getHobby(),
+                member.getProfileImageUrl(),
+                member.getBio(),
+                totalPostCount,
+                packs.size(),
+                feeds.size(),
+                packDtos,
+                feedDtos,
+                isMe
+        );
+    }
+}
+

--- a/src/main/java/com/starterpack/member/entity/Member.java
+++ b/src/main/java/com/starterpack/member/entity/Member.java
@@ -56,6 +56,12 @@ public class Member {
     @Column(name = "phone_number", length = 20)
     private String phoneNumber;
 
+    @Column(name = "hobby", length = 200)
+    private String hobby;
+
+    @Column(name = "bio", length = 500)
+    private String bio;
+
     @Column(name = "refresh_token", length = 500)
     private String refreshToken;
 

--- a/src/main/java/com/starterpack/member/service/MemberService.java
+++ b/src/main/java/com/starterpack/member/service/MemberService.java
@@ -3,8 +3,13 @@ package com.starterpack.member.service;
 import com.starterpack.member.dto.MemberCreationRequestDto;
 import com.starterpack.member.dto.MemberResponseDto;
 import com.starterpack.member.dto.MemberUpdateRequestDto;
+import com.starterpack.member.dto.MyPageResponseDto;
 import com.starterpack.member.entity.Member;
 import com.starterpack.member.repository.MemberRepository;
+import com.starterpack.pack.entity.Pack;
+import com.starterpack.pack.repository.PackRepository;
+import com.starterpack.feed.entity.Feed;
+import com.starterpack.feed.repository.FeedRepository;
 import com.starterpack.exception.BusinessException;
 import com.starterpack.exception.ErrorCode;
 import java.util.Optional;
@@ -23,6 +28,8 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final NicknameService nicknameService;
+    private final PackRepository packRepository;
+    private final FeedRepository feedRepository;
 
     // 모든 멤버 조회
     public List<Member> findAllMembers() {
@@ -159,5 +166,19 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
         member.updateRefreshToken(refreshToken);
+    }
+
+    // 마이페이지 조회
+    public MyPageResponseDto getMyPage(Long targetUserId, Long currentUserId) {
+        Member member = memberRepository.findById(targetUserId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<Pack> packs = packRepository.findByMemberId(targetUserId);
+        List<Feed> feeds = feedRepository.findByUserId(targetUserId, 
+                org.springframework.data.domain.Pageable.unpaged()).getContent();
+
+        boolean isMe = currentUserId != null && currentUserId.equals(targetUserId);
+
+        return MyPageResponseDto.from(member, packs, feeds, isMe);
     }
 }

--- a/src/main/java/com/starterpack/member/service/MemberService.java
+++ b/src/main/java/com/starterpack/member/service/MemberService.java
@@ -169,9 +169,15 @@ public class MemberService {
     }
 
     // 마이페이지 조회
+    @Transactional(readOnly = true)
     public MyPageResponseDto getMyPage(Long targetUserId, Long currentUserId) {
         Member member = memberRepository.findById(targetUserId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 비활성화된 회원은 조회 불가 (본인 제외)
+        if (!member.getIsActive() && (currentUserId == null || !currentUserId.equals(targetUserId))) {
+            throw new BusinessException(ErrorCode.MEMBER_NOT_FOUND);
+        }
 
         List<Pack> packs = packRepository.findByMemberId(targetUserId);
         List<Feed> feeds = feedRepository.findByUserId(targetUserId, 

--- a/src/main/java/com/starterpack/pack/repository/PackRepository.java
+++ b/src/main/java/com/starterpack/pack/repository/PackRepository.java
@@ -57,4 +57,23 @@ public interface PackRepository extends JpaRepository<Pack, Long> {
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Pack p SET p.packCommentCount = CASE WHEN p.packCommentCount > 0 THEN p.packCommentCount - 1 ELSE 0 END WHERE p.id = :id")
     void decrementCommentCount(@Param("id") Long id);
+
+    // 멤버별 팩 목록 조회
+    @Query("""
+        select distinct p
+        from Pack p
+        left join fetch p.items
+        left join fetch p.category
+        where p.member.userId = :memberId
+        order by p.id desc
+    """)
+    List<Pack> findByMemberId(@Param("memberId") Long memberId);
+
+    // 멤버별 팩 개수 조회
+    @Query("""
+        select count(p)
+        from Pack p
+        where p.member.userId = :memberId
+    """)
+    long countByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -37,6 +37,8 @@ CREATE TABLE member (
   birth_date         DATE,
   gender             VARCHAR(10),
   phone_number       VARCHAR(20),
+  hobby              VARCHAR(200),
+  bio                VARCHAR(500),
   refresh_token      VARCHAR(500),
   created_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/src/test/java/com/starterpack/member/service/MemberServiceMyPageTest.java
+++ b/src/test/java/com/starterpack/member/service/MemberServiceMyPageTest.java
@@ -1,0 +1,84 @@
+package com.starterpack.member.service;
+
+import com.starterpack.member.dto.MyPageResponseDto;
+import com.starterpack.member.entity.Member;
+import com.starterpack.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class MemberServiceMyPageTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    /**
+     * 비로그인 사용자가 마이페이지를 조회할 때 isMe가 false인지 확인
+     * - 닉네임, 취미, 한 줄 소개 필드가 정확히 매핑되는지 확인
+     */
+    @Test
+    void testMyPageForAnonymousUser_ReturnsIsMeFalse() {
+        // given
+        Member member = Member.createUser(
+                "test@test.com",
+                "password",
+                "Test Name",
+                "testnick",
+                Member.Provider.EMAIL,
+                "providerId",
+                null,
+                null,
+                null
+        );
+        member.setHobby("독서");
+        member.setBio("한 줄 소개");
+        member = memberRepository.save(member);
+
+        // when - 비로그인 사용자(null)가 마이페이지 조회
+        MyPageResponseDto response = memberService.getMyPage(member.getUserId(), null);
+
+        // then - isMe가 false이고 모든 필드가 정확히 매핑됨
+        assertThat(response).isNotNull();
+        assertThat(response.nickname()).isEqualTo("testnick");
+        assertThat(response.hobby()).isEqualTo("독서");
+        assertThat(response.bio()).isEqualTo("한 줄 소개");
+        assertThat(response.isMe()).isFalse();
+    }
+
+    /**
+     * 본인(userId == currentUserId)이 마이페이지를 조회할 때 isMe가 true인지 확인
+     */
+    @Test
+    void testMyPageForOwner_ReturnsIsMeTrue() {
+        // given
+        Member member = Member.createUser(
+                "test2@test.com",
+                "password",
+                "Test Name 2",
+                "testnick2",
+                Member.Provider.EMAIL,
+                "providerId2",
+                null,
+                null,
+                null
+        );
+        member = memberRepository.save(member);
+
+        // when - 본인(member.getUserId())이 자신의 마이페이지 조회
+        MyPageResponseDto response = memberService.getMyPage(member.getUserId(), member.getUserId());
+
+        // then - isMe가 true임
+        assertThat(response.isMe()).isTrue();
+    }
+}
+


### PR DESCRIPTION
### 📌 PR 타입
-[ ✅ ] 기능 추가
-[ ] 기능 삭제
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--lee-seung-won/mypageApi -> dev-->

### 🧑‍💻 구현한 내용
**Member 엔티티 :** 
- 프론트 요구사항에 맞게 hobby(취미), bio(한 줄 소개) 필드 추가

**Repository 메서드 추가 :**
- PackRepository: findByMemberId(), countByMemberId()
- FeedRepository: findByUserId(), countByUserId()

**DTO 생성 :**
- MyPageResponseDto: 닉네임, 취미, 프로필 이미지, 한 줄 소개, 게시물 수, 팩/피드 목록, isMe
- MyPagePackDto, MyPageFeedDto: 피드, 팩에서 무슨 데이터를 가져올 지 언제든 수정가능

**보안 설정 :**
- SecurityConfig permitAll, JwtTokenFilter publicUrls 추가

**Controller 엔드포인트: GET /api/members/{userId}/mypage**
**MemberService.getMyPage(): 마이페이지에 필요한 정보들을 조회**


### 🧪 테스트 결과
- N+1 문제 없음(join fetch, @EntityGraph 사용)
- 비활성 사용자 조회 차단 동작
- isMe 정상 판단
- 비로그인 사용자 접근 가능
- Repository 조회 2회(Member 1, Pack/Feed 1)
### 👿 트러블 슈팅

### 💬 코멘트
- 비활성 회원은 본인만 조회 가능
- isMe 판단은 서버에서 수행, 토큰과 조회 대상 비교 (조회한 대상이 본인인지 타사용자인지)
- 비로그인 사용자도 프로필 조회 가능하도록 설계



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View member profile pages showing nickname, hobby, bio, packs and feeds, and post counts.
  * Public access to member profile pages (GET) without requiring authentication.

* **Tests**
  * Added tests covering profile retrieval, field mappings, and owner vs anonymous access behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->