### PR TITLE
Lee seung won/modify feed admin page

### DIFF
--- a/src/main/java/com/starterpack/feed/service/FeedService.java
+++ b/src/main/java/com/starterpack/feed/service/FeedService.java
@@ -183,12 +183,18 @@ public class FeedService {
 
     @Transactional
     public void updateFeedByAdmin(Long feedId, FeedUpdateRequestDto request) {
-        Feed feed = getFeedById(feedId);
+        Feed feed = getFeedByIdWithDetails(feedId);
 
         Category category = getCategory(request.categoryId());
 
-
         feed.update(request.description(), request.imageUrl(), category);
+
+        // 해시태그 처리 로직 추가
+        List<Hashtag> hashtags = hashtagService.resolveHashtags(request.hashtagNames());
+        HashtagUpdateResult result = feed.updateHashtag(hashtags);
+
+        hashtagService.incrementUsageCount(result.added());
+        hashtagService.decrementUsageCount(result.removed());
     }
 
     @Transactional

--- a/src/main/resources/templates/admin/feed/detail.html
+++ b/src/main/resources/templates/admin/feed/detail.html
@@ -36,6 +36,15 @@
               <dt>작성자</dt><dd th:text="${feed.user.email}">user@example.com</dd>
               <dt>카테고리</dt><dd th:text="${feed.category != null ? feed.category.name : '미지정'}">카테고리</dd>
               <dt>좋아요 수</dt><dd th:text="${feed.likeCount}">0</dd>
+              <dt>해시태그</dt>
+              <dd>
+                <span th:if="${feed.hashtags != null and !feed.hashtags.isEmpty()}"
+                      th:each="hashtag, iterStat : ${feed.hashtags}">
+                  <span th:text="'#' + ${hashtag.name}">#태그</span>
+                  <span th:if="${!iterStat.last}">, </span>
+                </span>
+                <span th:if="${feed.hashtags == null or feed.hashtags.isEmpty()}" class="text-muted">없음</span>
+              </dd>
               <dt>작성일</dt><dd th:text="${#temporals.format(feed.createdAt, 'yyyy-MM-dd HH:mm:ss')}">2024-01-01 12:00:00</dd>
               <dt>수정일</dt><dd th:text="${#temporals.format(feed.updatedAt, 'yyyy-MM-dd HH:mm:ss')}">2024-01-01 12:00:00</dd>
             </dl>

--- a/src/main/resources/templates/admin/feed/form.html
+++ b/src/main/resources/templates/admin/feed/form.html
@@ -49,6 +49,14 @@
             </select>
           </div>
 
+          <div class="field">
+            <label for="hashtagNames">해시태그 (쉼표로 구분)</label>
+            <input type="text" id="hashtagNames" name="hashtagNames" 
+                   th:value="${isEdit ? #strings.listJoin(feed.hashtags.![name], ', ') : ''}" 
+                   placeholder="예: 해시태그1, 해시태그2, 해시태그3"/>
+            <small class="text-xs text-muted">최대 10개까지 가능합니다.</small>
+          </div>
+
           <div class="btnbar">
             <button type="submit" class="btn btn-primary">저장</button>
             <a th:href="@{/admin/feeds}" class="btn">취소</a>
@@ -58,20 +66,5 @@
     </div>
   </main>
 </div>
-
-
-<template id="product-item-template">
-  <div class="product-item">
-    <div class="product-item-header">
-      <strong class="product-title">상품</strong>
-      <button type="button" class="remove-product-btn">삭제</button>
-    </div>
-    <div class="product-fields">
-      <input type="text" class="product-name" placeholder="상품명" required>
-      <input type="url" class="product-image-url" placeholder="상품 이미지 URL">
-      <textarea class="product-description" placeholder="상품 설명" rows="2"></textarea>
-    </div>
-  </div>
-</template>
 </body>
 </html>


### PR DESCRIPTION
### 📌 PR 타입
-[✅ ] 기능 추가
-[ ] 기능 삭제
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--lee-seung-won/modify_feedAdminPage -> dev-->

### 📄 관련 이슈
<!-- 이슈번호 -->

### 🧑‍💻 구현한 내용
관리자 페이지에 해시태그 삽입 기능을 추가하였습니다.
### 🧪 테스트 결과

### 👿 트러블 슈팅

### 💬 코멘트





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Hashtag management: Administrators can now add and manage hashtags when updating feed items with automatic usage tracking
  * Feed detail view now displays all associated hashtags
  * Feed edit forms include a hashtag input field for managing tags during creation and editing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->