### PR TITLE
feat: 스타터팩 관리자 페이지에 해시태그 입력 필드 추가

### DIFF
--- a/src/main/resources/templates/admin/packs/form.html
+++ b/src/main/resources/templates/admin/packs/form.html
@@ -114,6 +114,16 @@
                 <textarea id="description" th:field="*{description}" th:classappend="${#fields.hasErrors('description')} ? 'invalid'"></textarea>
                 <div class="error" th:errors="*{description}"></div>
               </div>
+
+              <div class="field">
+                <label for="hashtagNames">해시태그 (쉼표로 구분)</label>
+                <input type="text" id="hashtagNames" name="hashtagNames" 
+                       th:value="${isEdit ? (#strings.listJoin(packDto.hashtagNames, ', ')) : ''}" 
+                       th:classappend="${#fields.hasErrors('hashtagNames')} ? 'invalid'"
+                       placeholder="예: 해시태그1, 해시태그2, 해시태그3"/>
+                <div class="error" th:errors="*{hashtagNames}"></div>
+                <div class="small muted">최대 10개까지 가능합니다.</div>
+              </div>
             </div>
 
             <!-- 우측: PackItem 관리 -->


### PR DESCRIPTION
### 📌 PR 타입
-[ ✅] 기능 추가
-[ ] 기능 삭제
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--lee-seung-won/modify_starterpackAdminPage -> dev-->

### 📄 관련 이슈
<!-- 이슈번호: -->

### 🧑‍💻 구현한 내용
스타터팩 관리자 페이지 프론트엔드를 수정하여 해시태그를 입력받게 하였습니다.

### 🧪 테스트 결과
<img width="582" height="635" alt="image" src="https://github.com/user-attachments/assets/95e17080-7812-46e7-8e4e-f6a04664b323" />

### 👿 트러블 슈팅

### 💬 코멘트





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hashtag input field to the admin pack form, enabling users to manage up to 10 comma-separated hashtags with validation and automatic population of existing hashtags in edit mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->