### PR TITLE
fix: 해시태그 로직 리팩터링 및 NPE 버그 수정

### DIFF
--- a/src/main/java/com/starterpack/feed/entity/Feed.java
+++ b/src/main/java/com/starterpack/feed/entity/Feed.java
@@ -128,6 +128,10 @@ public class Feed {
     }
 
     private void setFeedHashtags(List<Hashtag> hashtags) {
+        if (hashtags == null) { //NPE 방지
+            return;
+        }
+
         this.feedHashtags.clear();
         for (int i = 0; i < hashtags.size(); i++) {
             this.feedHashtags.add(new FeedHashtag(this, hashtags.get(i), i));

--- a/src/main/java/com/starterpack/feed/service/FeedService.java
+++ b/src/main/java/com/starterpack/feed/service/FeedService.java
@@ -23,7 +23,6 @@ import com.starterpack.hashtag.service.HashtagService;
 import com.starterpack.member.entity.Member;
 import jakarta.persistence.EntityManager;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -61,7 +60,7 @@ public class FeedService {
                 .hashtags(hashtags)
                 .build();
 
-        hashtagService.incrementUsageCount(new HashSet<>(hashtags));
+        hashtagService.incrementUsageCount(hashtags);
 
         return feedRepository.save(feed);
     }
@@ -135,7 +134,7 @@ public class FeedService {
         feed.validateOwner(member);
 
         List<Hashtag> hashtags = feed.getHashtags();
-        hashtagService.decrementUsageCount(new HashSet<>(hashtags));
+        hashtagService.decrementUsageCount(hashtags);
 
         feedRepository.delete(feed);
     }

--- a/src/main/java/com/starterpack/hashtag/service/HashtagService.java
+++ b/src/main/java/com/starterpack/hashtag/service/HashtagService.java
@@ -3,6 +3,7 @@ package com.starterpack.hashtag.service;
 
 import com.starterpack.hashtag.entity.Hashtag;
 import com.starterpack.hashtag.repository.HashtagRepository;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -42,7 +43,7 @@ public class HashtagService {
     }
 
     @Transactional
-    public void incrementUsageCount(Set<Hashtag> hashtags) {
+    public void incrementUsageCount(Collection<Hashtag> hashtags) {
         if (hashtags == null || hashtags.isEmpty()) return;
 
         Set<Long> ids = hashtags.stream()
@@ -53,7 +54,7 @@ public class HashtagService {
     }
 
     @Transactional
-    public void decrementUsageCount(Set<Hashtag> hashtags) {
+    public void decrementUsageCount(Collection<Hashtag> hashtags) {
         if (hashtags == null || hashtags.isEmpty()) return;
 
         Set<Long> ids = hashtags.stream()

--- a/src/main/java/com/starterpack/pack/entity/Pack.java
+++ b/src/main/java/com/starterpack/pack/entity/Pack.java
@@ -15,7 +15,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.core.annotation.Order;
 
 @Entity
 @Getter

--- a/src/main/java/com/starterpack/pack/entity/Pack.java
+++ b/src/main/java/com/starterpack/pack/entity/Pack.java
@@ -63,6 +63,7 @@ public class Pack {
 
     @org.hibernate.annotations.BatchSize(size = 100)
     @OneToMany(mappedBy = "pack", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("tagOrder ASC")
     private List<PackHashtag> packHashtags = new ArrayList<>();
 
     public void changeName(String name) {

--- a/src/main/java/com/starterpack/pack/entity/Pack.java
+++ b/src/main/java/com/starterpack/pack/entity/Pack.java
@@ -15,6 +15,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.core.annotation.Order;
 
 @Entity
 @Getter
@@ -186,6 +187,10 @@ public class Pack {
     }
 
     private void setPackHashtags(List<Hashtag> hashtags) {
+        if (hashtags == null) {
+            return;
+        }
+
         this.packHashtags.clear();
         for (int i = 0; i < hashtags.size(); i++) {
             this.packHashtags.add(new PackHashtag(this, hashtags.get(i), i));

--- a/src/main/java/com/starterpack/pack/service/PackService.java
+++ b/src/main/java/com/starterpack/pack/service/PackService.java
@@ -104,7 +104,7 @@ public class PackService {
             }
         }
 
-        hashtagService.incrementUsageCount(new HashSet<>(hashtags));
+        hashtagService.incrementUsageCount(hashtags);
 
         return packRepository.save(pack);
     }
@@ -168,7 +168,7 @@ public class PackService {
         validatePackOwnership(pack, member);
 
         List<Hashtag> hashtags = pack.getHashtags();
-        hashtagService.decrementUsageCount(new HashSet<>(hashtags));
+        hashtagService.decrementUsageCount(hashtags);
 
         packRepository.delete(pack);
     }


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--feat/login -> dev-->
fixFeed -> develop
### 📄 관련 이슈
<!-- 이슈번호: #334 -->

### 🧑‍💻 구현한 내용
1. 버그 수정: Feed, Pack 생성 시 NPE 발생 문제 해결
    - PATCH (수정) 요청 시, '해시태그 변경 안 함' (null 전송)과 '모든 해시태그 삭제' ([] 전송)를 구분해야 했습니다. 이 때문에 HashtagService.resolveHashtags는 null을 그대로 반환하도록 설계되었습니다.

    - 문제: 이 설계로 인해, POST (생성) 요청 시에도 hashtagNames가 null일 때 resolveHashtags가 null을 반환했고, 이 값이 엔티티(Feed, Pack) 생성자로 전달되었습니다.

    - 원인: 엔티티 내부의 private setFeedHashtags(null) 메서드가 null 체크 없이 hashtags.size()를 호출하여 NPE가 발생했습니다.

    - 해결: Feed.java와 Pack.java의 setFeedHashtags/setPackHashtags 메서드 내부에 clear()를 호출하기 전에 null 방어 로직을 추가했습니다. 

2. 리팩터링: HashtagService 캡슐화 및 NPE 방어
    - FeedService.addFeed 내부에서 incrementUsageCount 호출 시 new HashSet<>(null)이 실행되어 NPE가 발생하는 2차 문제가 있었습니다.

    - 해결: HashtagService가 null을 스스로 처리하도록 캡슐화했습니다.
    - incrementUsageCount, decrementUsageCount 메서드의 파라미터 타입을 Set<Hashtag>에서 공통 부모 인터페이스인 Collection<Hashtag>으로 변경했습니다. 따라서 new HashSet<> 을 할 필요가 없게 했습니다.
 3. 추가적으로 Feed엔 적용했으나 Pack에 `@OrderBy("tagOrder ASC")` 를 누락하여 이를 추가했습니다.
### 🧪 테스트 결과
PATCH hashtagNames 빠진 경우(즉, 해시태그는 변경 X)
요청: 
```
{

}
```
응답:
```
    "hashtags": [
        {
            "id": 2,
            "hashtagName": "러닝"
        }
    ]
```
PATCH hashtagNames 가 빈 리스트인 경우(해시태그 비우고 싶은 경우)
요청: 
```
{
    "hashtagNames" : []
}
```
응답: 
```
   "hashtags": []
```
### 👿 트러블 슈팅

### 💬 코멘트





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability with null safety checks in feed and pack management to prevent potential initialization errors.

* **Refactor**
  * Improved hashtag collection handling for better flexibility and performance.
  * Ensured consistent hashtag ordering across pack operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->