### PR TITLE
feat: 카카오 외부 API 호출시 RestClient 사용하도록 변경 및 에러 핸들링 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 	implementation 'org.apache.commons:commons-text:1.12.0'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'software.amazon.awssdk:s3:2.20.26'
 }
 

--- a/src/main/java/com/starterpack/auth/kakao/KakaoApiClient.java
+++ b/src/main/java/com/starterpack/auth/kakao/KakaoApiClient.java
@@ -2,17 +2,26 @@ package com.starterpack.auth.kakao;
 
 import com.starterpack.auth.dto.KakaoTokenResponseDto;
 import com.starterpack.auth.dto.KakaoUserInfoResponseDto;
+import com.starterpack.exception.KakaoAuthException;
+import com.starterpack.exception.KakaoServerException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
 
 @Component
 @RequiredArgsConstructor
 public class KakaoApiClient {
+
+    private static final int CONNECTION_TIMEOUT_MS = 5000;  // 5초
+    private static final int READ_TIMEOUT_MS = 10000;
+
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String clientId;
     @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
@@ -21,6 +30,18 @@ public class KakaoApiClient {
     private String tokenUri;
     @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
     private String userInfoUri;
+
+    private final RestClient restClient;
+
+    public KakaoApiClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(CONNECTION_TIMEOUT_MS);
+        requestFactory.setReadTimeout(READ_TIMEOUT_MS);
+
+        this.restClient = RestClient.builder()
+                .requestFactory(requestFactory)
+                .build();
+    }
 
     /**
      * 인가 코드를 사용하여 카카오로부터 액세스 토큰을 받아옵니다.
@@ -32,24 +53,50 @@ public class KakaoApiClient {
         formData.add("redirect_uri", redirectUri);
         formData.add("code", code);
 
-        return WebClient.create()
-                .post().uri(tokenUri)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .bodyValue(formData)
-                .retrieve()
-                .bodyToMono(KakaoTokenResponseDto.class)
-                .block();
+        try {
+            return restClient.post()
+                    .uri(tokenUri)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                        throw new KakaoAuthException(
+                                "카카오 토큰 발급 실패 - 응답 코드: " + response.getStatusCode()
+                        );
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                        throw new KakaoServerException(
+                                "카카오 서버 오류 - 응답 코드: " + response.getStatusCode()
+                        );
+                    })
+                    .body(KakaoTokenResponseDto.class);
+        } catch (ResourceAccessException e) {
+            throw new KakaoServerException("카카오 서버 연결 실패 (타임아웃 또는 네트워크 오류)");
+        }
     }
 
     /**
      * 액세스 토큰을 사용하여 카카오 API로부터 사용자 정보를 받아옵니다.
      */
     public KakaoUserInfoResponseDto fetchUserInfo(String accessToken) {
-        return WebClient.create()
-                .get().uri(userInfoUri)
-                .headers(header -> header.setBearerAuth(accessToken))
-                .retrieve()
-                .bodyToMono(KakaoUserInfoResponseDto.class)
-                .block();
+        try {
+            return restClient.get()
+                    .uri(userInfoUri)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                        throw new KakaoAuthException(
+                                "카카오 사용자 정보 조회 실패 - 응답 코드: " + response.getStatusCode()
+                        );
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                        throw new KakaoServerException(
+                                "카카오 서버 오류 - 응답 코드: " + response.getStatusCode()
+                        );
+                    })
+                    .body(KakaoUserInfoResponseDto.class);
+        } catch (ResourceAccessException e) {
+            throw new KakaoServerException("카카오 서버 연결 실패 (타임아웃 또는 네트워크 오류)");
+        }
     }
 }

--- a/src/main/java/com/starterpack/auth/kakao/KakaoApiClient.java
+++ b/src/main/java/com/starterpack/auth/kakao/KakaoApiClient.java
@@ -4,6 +4,7 @@ import com.starterpack.auth.dto.KakaoTokenResponseDto;
 import com.starterpack.auth.dto.KakaoUserInfoResponseDto;
 import com.starterpack.exception.KakaoAuthException;
 import com.starterpack.exception.KakaoServerException;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
@@ -35,8 +36,8 @@ public class KakaoApiClient {
 
     public KakaoApiClient() {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(CONNECTION_TIMEOUT_MS);
-        requestFactory.setReadTimeout(READ_TIMEOUT_MS);
+        requestFactory.setConnectTimeout(Duration.ofMillis(CONNECTION_TIMEOUT_MS));
+        requestFactory.setReadTimeout(Duration.ofMillis(READ_TIMEOUT_MS));
 
         this.restClient = RestClient.builder()
                 .requestFactory(requestFactory)

--- a/src/main/java/com/starterpack/auth/service/AuthService.java
+++ b/src/main/java/com/starterpack/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import com.starterpack.auth.jwt.JwtTokenUtil;
 import com.starterpack.auth.kakao.KakaoApiClient;
 import com.starterpack.exception.BusinessException;
 import com.starterpack.auth.dto.LocalSignUpRequestDto;
+import com.starterpack.exception.KakaoAuthException;
 import com.starterpack.member.dto.MemberCreationRequestDto;
 import com.starterpack.member.dto.MemberResponseDto;
 import com.starterpack.member.entity.Member;
@@ -120,7 +121,13 @@ public class AuthService {
     public TokenResponseDto kakaoLogin(String code) {
         //  Kakao Api Client를 통해 액세스 토큰 및 사용자 정보 조회
         KakaoTokenResponseDto kakaoToken = kakaoApiClient.fetchAccessToken(code);
+        if (kakaoToken == null) {
+            throw new KakaoAuthException("Kakao token response was empty");
+        }
         KakaoUserInfoResponseDto userInfo = kakaoApiClient.fetchUserInfo(kakaoToken.accessToken());
+        if (userInfo == null) {
+            throw new KakaoAuthException("사용자 정보 조회 실패: 응답 본문이 비어있음");
+        }
 
         // userInfo를 토대로 MemberCreationRequestDto 생성
         MemberCreationRequestDto creationRequest = MemberCreationRequestDto.fromKakao(userInfo);

--- a/src/main/java/com/starterpack/auth/service/AuthService.java
+++ b/src/main/java/com/starterpack/auth/service/AuthService.java
@@ -122,7 +122,7 @@ public class AuthService {
         //  Kakao Api Client를 통해 액세스 토큰 및 사용자 정보 조회
         KakaoTokenResponseDto kakaoToken = kakaoApiClient.fetchAccessToken(code);
         if (kakaoToken == null) {
-            throw new KakaoAuthException("Kakao token response was empty");
+            throw new KakaoAuthException("카카오 토큰 발급 실패: 응답 본문이 비어있음");
         }
         KakaoUserInfoResponseDto userInfo = kakaoApiClient.fetchUserInfo(kakaoToken.accessToken());
         if (userInfo == null) {

--- a/src/main/java/com/starterpack/exception/ErrorCode.java
+++ b/src/main/java/com/starterpack/exception/ErrorCode.java
@@ -101,6 +101,13 @@ public enum ErrorCode {
     INVALID_FILE_PATH(HttpStatus.BAD_REQUEST,
             "S3_004",
             "유효하지 않은 파일 경로입니다."),
+    //Kakao
+    KAKAO_AUTH_ERROR(HttpStatus.BAD_REQUEST,
+            "K001",
+            "카카오 인증에 실패했습니다."),
+    KAKAO_SERVER_ERROR(HttpStatus.SERVICE_UNAVAILABLE,
+            "K002",
+            "카카오 서버와 통신에 문제가 발생했습니다."),
 
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "FC001", "해당하는 댓글을 찾을 수 없습니다."),
     COMMENT_ALREADY_DELETED(HttpStatus.CONFLICT, "FC002", "이미 삭제된 댓글입니다.");

--- a/src/main/java/com/starterpack/exception/KakaoAuthException.java
+++ b/src/main/java/com/starterpack/exception/KakaoAuthException.java
@@ -1,0 +1,11 @@
+package com.starterpack.exception;
+
+public class KakaoAuthException extends BusinessException {
+    public KakaoAuthException() {
+        super(ErrorCode.KAKAO_AUTH_ERROR);
+    }
+
+    public KakaoAuthException(String detailMessage) {
+        super(ErrorCode.KAKAO_AUTH_ERROR, detailMessage);
+    }
+}

--- a/src/main/java/com/starterpack/exception/KakaoServerException.java
+++ b/src/main/java/com/starterpack/exception/KakaoServerException.java
@@ -1,0 +1,11 @@
+package com.starterpack.exception;
+
+public class KakaoServerException extends BusinessException {
+    public KakaoServerException() {
+        super(ErrorCode.KAKAO_SERVER_ERROR);
+    }
+
+    public KakaoServerException(String detailMessage) {
+        super(ErrorCode.KAKAO_SERVER_ERROR, detailMessage);
+    }
+}


### PR DESCRIPTION
### 📌 PR 타입
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--sanghyeon1225/kakaoClient -> develop-->

### 📄 관련 이슈

### 🧑‍💻 구현한 내용
- WebClient를 매 요청마다 새로 생성하여 메모리 낭비
- 따라서 동기 방식에 최적화 된 RestClient를 사용하도록 리팩토링
- 싱글톤 패턴으로 RestClient 인스턴스 한 번만 생성
- 불필요한 `spring-boot-starter-webflux` 의존성 제거

- 타임아웃 설정 추가 -> 외부 API 장애 시 무한 대기 방지로 시스템 안정성 확보
- `연결 타임아웃`: 5초 (카카오 서버 연결 실패 시)
- `읽기 타임아웃`: 10초 (카카오 서버 응답 지연 시)

- `KakaoAuthException`: 4xx 클라이언트 에러 처리 (잘못된 인가 코드, 만료된 토큰 등)
- `KakaoServerException`: 5xx 서버 에러 및 네트워크 오류 처리 (타임아웃, 연결 실패 등)
### 🧪 테스트 결과

### 👿 트러블 슈팅

### 💬 코멘트





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Timeouts added to Kakao API requests to reduce hangs and improve reliability.
  - Distinct, user-facing error types for Kakao authentication failures vs. Kakao server issues.

* **Bug Fixes**
  - Improved handling of missing token/user responses and connectivity errors to reduce intermittent login failures.

* **Chores**
  - Removed reactive web support to streamline HTTP client behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->