### PR TITLE
feat: 좋아요, 북마크 수(팩, 피드) 경쟁상태 방어로직 추가

### DIFF
--- a/src/main/java/com/starterpack/feed/dto/FeedBookmarkResponseDto.java
+++ b/src/main/java/com/starterpack/feed/dto/FeedBookmarkResponseDto.java
@@ -6,11 +6,11 @@ public record FeedBookmarkResponseDto(
     private static final FeedBookmarkResponseDto BOOKMARKED = new FeedBookmarkResponseDto(true);
     private static final FeedBookmarkResponseDto UNBOOKMARKED = new FeedBookmarkResponseDto(false);
 
-    public static FeedBookmarkResponseDto bookmared() {
+    public static FeedBookmarkResponseDto bookmarked() {
         return BOOKMARKED;
     }
 
-    public static FeedBookmarkResponseDto unbookmared() {
+    public static FeedBookmarkResponseDto unbookmarked() {
         return UNBOOKMARKED;
     }
 }

--- a/src/main/java/com/starterpack/feed/dto/FeedBookmarkResponseDto.java
+++ b/src/main/java/com/starterpack/feed/dto/FeedBookmarkResponseDto.java
@@ -3,14 +3,14 @@ package com.starterpack.feed.dto;
 public record FeedBookmarkResponseDto(
         Boolean isBookmarked
 ) {
-    private static final FeedBookmarkResponseDto BOOKMARED = new FeedBookmarkResponseDto(true);
-    private static final FeedBookmarkResponseDto UNBOOKMARED = new FeedBookmarkResponseDto(false);
+    private static final FeedBookmarkResponseDto BOOKMARKED = new FeedBookmarkResponseDto(true);
+    private static final FeedBookmarkResponseDto UNBOOKMARKED = new FeedBookmarkResponseDto(false);
 
     public static FeedBookmarkResponseDto bookmared() {
-        return BOOKMARED;
+        return BOOKMARKED;
     }
 
     public static FeedBookmarkResponseDto unbookmared() {
-        return UNBOOKMARED;
+        return UNBOOKMARKED;
     }
 }

--- a/src/main/java/com/starterpack/feed/dto/FeedBookmarkResponseDto.java
+++ b/src/main/java/com/starterpack/feed/dto/FeedBookmarkResponseDto.java
@@ -3,7 +3,14 @@ package com.starterpack.feed.dto;
 public record FeedBookmarkResponseDto(
         Boolean isBookmarked
 ) {
-    public static FeedBookmarkResponseDto of(Boolean isBookmarked) {
-        return new FeedBookmarkResponseDto(isBookmarked);
+    private static final FeedBookmarkResponseDto BOOKMARED = new FeedBookmarkResponseDto(true);
+    private static final FeedBookmarkResponseDto UNBOOKMARED = new FeedBookmarkResponseDto(false);
+
+    public static FeedBookmarkResponseDto bookmared() {
+        return BOOKMARED;
+    }
+
+    public static FeedBookmarkResponseDto unbookmared() {
+        return UNBOOKMARED;
     }
 }

--- a/src/main/java/com/starterpack/feed/dto/FeedLikeResponseDto.java
+++ b/src/main/java/com/starterpack/feed/dto/FeedLikeResponseDto.java
@@ -4,7 +4,11 @@ public record FeedLikeResponseDto(
         Long likeCount,
         Boolean isLiked
 ) {
-    public static FeedLikeResponseDto of(Long likeCount, Boolean isLiked) {
-        return new FeedLikeResponseDto(likeCount, isLiked);
+    public static FeedLikeResponseDto liked(Long likeCount) {
+        return new FeedLikeResponseDto(likeCount, true);
+    }
+
+    public static FeedLikeResponseDto unliked(Long likeCount) {
+        return new FeedLikeResponseDto(likeCount, false);
     }
 }

--- a/src/main/java/com/starterpack/feed/repository/FeedBookmarkRepository.java
+++ b/src/main/java/com/starterpack/feed/repository/FeedBookmarkRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface FeedBookmarkRepository extends JpaRepository<FeedBookmark, Long> {
     boolean existsByFeedAndMember(Feed feed, Member member);
-    void deleteByFeedAndMember(Feed feed, Member member);
+    int deleteByFeedAndMember(Feed feed, Member member);
 
     @Query("SELECT fb.feed.id FROM FeedBookmark fb WHERE fb.member = :member AND fb.feed.id IN :feedIds")
     Set<Long> findFeedIdsByMemberAndFeedIds(@Param("member")Member member, @Param("feedIds") List<Long> feedIds);

--- a/src/main/java/com/starterpack/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/starterpack/feed/repository/FeedLikeRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
     boolean existsByFeedAndMember(Feed feed, Member member);
-    void deleteByFeedAndMember(Feed feed, Member member);
+    int deleteByFeedAndMember(Feed feed, Member member);
 
     @Query("SELECT fl FROM FeedLike fl JOIN FETCH fl.member WHERE fl.feed = :feed")
     Page<FeedLike> findByFeed(@Param("feed") Feed feed, Pageable pageable);

--- a/src/main/java/com/starterpack/feed/service/FeedService.java
+++ b/src/main/java/com/starterpack/feed/service/FeedService.java
@@ -220,11 +220,11 @@ public class FeedService {
 
         if (deletedRows > 0) {
             feedRepository.decrementBookmarkCount(feedId);
-            return FeedBookmarkResponseDto.unbookmared();
+            return FeedBookmarkResponseDto.unbookmarked();
         } else {
             feedBookmarkRepository.save(new FeedBookmark(feed, member));
             feedRepository.incrementBookmarkCount(feedId);
-            return FeedBookmarkResponseDto.bookmared();
+            return FeedBookmarkResponseDto.bookmarked();
         }
     }
 

--- a/src/main/java/com/starterpack/feed/service/FeedService.java
+++ b/src/main/java/com/starterpack/feed/service/FeedService.java
@@ -216,17 +216,16 @@ public class FeedService {
     public FeedBookmarkResponseDto toggleFeedBookmark(Long feedId, Member member) {
         Feed feed = getFeedById(feedId);
 
-        boolean exists = feedBookmarkRepository.existsByFeedAndMember(feed, member);
+        int deletedRows = feedBookmarkRepository.deleteByFeedAndMember(feed, member);
 
-        if (exists) {
-            feedBookmarkRepository.deleteByFeedAndMember(feed, member);
+        if (deletedRows > 0) {
             feedRepository.decrementBookmarkCount(feedId);
+            return FeedBookmarkResponseDto.unbookmared();
         } else {
             feedBookmarkRepository.save(new FeedBookmark(feed, member));
             feedRepository.incrementBookmarkCount(feedId);
+            return FeedBookmarkResponseDto.bookmared();
         }
-
-        return FeedBookmarkResponseDto.of(!exists);
     }
 
     private Map<Long, InteractionStatusResponseDto> getFeedInteractionStatusMap(Member member, List<Feed> feeds) {

--- a/src/main/java/com/starterpack/feed/service/FeedService.java
+++ b/src/main/java/com/starterpack/feed/service/FeedService.java
@@ -143,19 +143,19 @@ public class FeedService {
     public FeedLikeResponseDto toggleFeedLike(Long feedId, Member liker) {
         Feed feed = getFeedById(feedId);
 
-        boolean exists = feedLikeRepository.existsByFeedAndMember(feed, liker);
+        int deletedRows = feedLikeRepository.deleteByFeedAndMember(feed, liker);
 
-        if (exists) {
-            feedLikeRepository.deleteByFeedAndMember(feed, liker);
+        if (deletedRows > 0) {
             feedRepository.decrementLikeCount(feedId);
+            entityManager.refresh(feed);
+            return FeedLikeResponseDto.unliked(feed.getLikeCount());
+
         } else {
             feedLikeRepository.save(new FeedLike(feed, liker));
             feedRepository.incrementLikeCount(feedId);
+            entityManager.refresh(feed);
+            return FeedLikeResponseDto.liked(feed.getLikeCount());
         }
-
-        entityManager.refresh(feed);
-
-        return FeedLikeResponseDto.of(feed.getLikeCount(), !exists);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/starterpack/pack/dto/PackBookmarkResponseDto.java
+++ b/src/main/java/com/starterpack/pack/dto/PackBookmarkResponseDto.java
@@ -3,7 +3,14 @@ package com.starterpack.pack.dto;
 public record PackBookmarkResponseDto(
         Boolean isBookmarked
 ) {
-    public static PackBookmarkResponseDto of(Boolean isBookmarked) {
-        return new PackBookmarkResponseDto(isBookmarked);
+    private static final PackBookmarkResponseDto BOOKMARKED = new PackBookmarkResponseDto(true);
+    private static final PackBookmarkResponseDto UNBOOKMARKED = new PackBookmarkResponseDto(false);
+
+    public static PackBookmarkResponseDto bookmarked() {
+        return BOOKMARKED;
+    }
+
+    public static PackBookmarkResponseDto unbookmarked() {
+        return UNBOOKMARKED;
     }
 }

--- a/src/main/java/com/starterpack/pack/dto/PackLikeResponseDto.java
+++ b/src/main/java/com/starterpack/pack/dto/PackLikeResponseDto.java
@@ -4,10 +4,6 @@ public record PackLikeResponseDto(
         Integer likeCount,
         Boolean isLiked
 ) {
-    public static PackLikeResponseDto of(Integer likeCount, Boolean isLiked) {
-        return new PackLikeResponseDto(likeCount, isLiked);
-    }
-
     public static PackLikeResponseDto liked(Integer likeCount) {
         return new PackLikeResponseDto(likeCount, true);
     }

--- a/src/main/java/com/starterpack/pack/dto/PackLikeResponseDto.java
+++ b/src/main/java/com/starterpack/pack/dto/PackLikeResponseDto.java
@@ -7,4 +7,12 @@ public record PackLikeResponseDto(
     public static PackLikeResponseDto of(Integer likeCount, Boolean isLiked) {
         return new PackLikeResponseDto(likeCount, isLiked);
     }
+
+    public static PackLikeResponseDto liked(Integer likeCount) {
+        return new PackLikeResponseDto(likeCount, true);
+    }
+
+    public static PackLikeResponseDto unliked(Integer likeCount) {
+        return new PackLikeResponseDto(likeCount, false);
+    }
 }

--- a/src/main/java/com/starterpack/pack/repository/PackBookmarkRepository.java
+++ b/src/main/java/com/starterpack/pack/repository/PackBookmarkRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PackBookmarkRepository extends JpaRepository<PackBookmark, Long> {
     boolean existsByPackAndMember(Pack pack, Member member);
-    void deleteByPackAndMember(Pack pack, Member member);
+    int deleteByPackAndMember(Pack pack, Member member);
 }

--- a/src/main/java/com/starterpack/pack/repository/PackLikeRepository.java
+++ b/src/main/java/com/starterpack/pack/repository/PackLikeRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface PackLikeRepository extends JpaRepository<PackLike, Long> {
     boolean existsByPackAndMember(Pack pack, Member member);
-    void deleteByPackAndMember(Pack pack, Member member);
+    int deleteByPackAndMember(Pack pack, Member member);
 
     @Query("SELECT pl FROM PackLike pl JOIN FETCH  pl.member WHERE pl.pack = :pack")
     Page<PackLike> findByPack(@Param("pack") Pack pack, Pageable pageable);

--- a/src/main/java/com/starterpack/pack/service/PackService.java
+++ b/src/main/java/com/starterpack/pack/service/PackService.java
@@ -213,17 +213,16 @@ public class PackService {
     public PackBookmarkResponseDto togglePackBookmark(Long id, Member member) {
         Pack pack = findPackById(id);
 
-        boolean exists = packBookmarkRepository.existsByPackAndMember(pack, member);
+        int deletedRows = packBookmarkRepository.deleteByPackAndMember(pack, member);
 
-        if (exists) {
-            packBookmarkRepository.deleteByPackAndMember(pack, member);
+        if (deletedRows > 0) {
             packRepository.decrementPackBookmarkCount(id);
+            return PackBookmarkResponseDto.unbookmarked();
         } else {
             packBookmarkRepository.save(new PackBookmark(pack, member));
             packRepository.incrementPackBookmarkCount(id);
+            return PackBookmarkResponseDto.bookmarked();
         }
-
-        return PackBookmarkResponseDto.of(!exists);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/starterpack/pack/service/PackService.java
+++ b/src/main/java/com/starterpack/pack/service/PackService.java
@@ -195,19 +195,18 @@ public class PackService {
     public PackLikeResponseDto togglePackLike(Long id, Member member) {
         Pack pack = findPackById(id);
 
-        boolean exists = packLikeRepository.existsByPackAndMember(pack, member);
+        int deletedRows = packLikeRepository.deleteByPackAndMember(pack, member);
 
-        if (exists) {
-            packLikeRepository.deleteByPackAndMember(pack, member);
+        if (deletedRows > 0) {
             packRepository.decrementLikeCount(id);
+            entityManager.refresh(pack);
+            return PackLikeResponseDto.unliked(pack.getPackLikeCount());
         } else {
             packLikeRepository.save(new PackLike(pack, member));
             packRepository.incrementLikeCount(id);
+            entityManager.refresh(pack);
+            return PackLikeResponseDto.liked(pack.getPackLikeCount());
         }
-
-        entityManager.refresh(pack);
-
-        return PackLikeResponseDto.of(pack.getPackLikeCount(), !exists);
     }
 
     @Transactional


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--feat/login -> dev-->
jihwan38/countRefactor -> develop
### 📄 관련 이슈
<!-- 이슈번호: #334 -->

### 🧑‍💻 구현한 내용
1. SELECT 후 DELETE 로직을 DELETE 선시도 로직으로 변경
    - existsBy... 쿼리로 객체 존재 여부를 먼저 확인하던 로직을 제거. 대신, deleteBy... 쿼리를 즉시 실행하고 Spring Data JPA의 기능을 활용해 삭제된 행의 개수(int)를 반환받도록 각 Repository(FeedLikeRepository, FeedBookmarkRepository 등)를 수정.

2. delete 반환값에 따른 분기 처리 (경쟁 상태 해결)
    - FeedService와 PackService의 토글 메서드(toggleFeedLike 등)에서 deleteBy...의 반환값을 확인하여 로직을 분기.
    - deletedRows > 0 (삭제 성공 시)
기존에 데이터가 있었으며 정상적으로 '취소(unlike/unbookmark)'되었음을 의미
decrementCount()를 호출하고 unliked() 또는 unbookmarked() 상태를 반환

    - deletedRows == 0 (삭제 실패 시)
기존에 데이터가 없었음을 의미하므로 '추가(like/bookmark)' 로직을 수행
save() 및 incrementCount()를 호출하고 liked() 또는 bookmarked() 상태를 반환

    - 이 방식은 DELETE 작업 자체를 존재 확인으로 사용하여, SELECT와 DELETE 사이의 간격을 없애고 경쟁 상태를 원천적으로 차단합니다.

3. DTO 정적 팩토리 메서드 적용 
    - FeedLikeResponseDto, PackBookmarkResponseDto 등에 liked(), unliked(), bookmarked(), unbookmarked()와 같은 정적 팩토리 메서드를 추가. 
    -> 서비스 로직에서 of(true), of(false) 대신 의미가 명확한 메서드를 호출하도록 변경하여 코드 가독성을 높임.

### 🧪 테스트 결과
포스트맨을 통해 기존 toggleBookmark(), toggleLike() 테스트 결과 모두 정상 작동하는 것을 확인했습니다.
### 👿 트러블 슈팅

### 💬 코멘트





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable like/bookmark toggles for feeds and packs; counts now update immediately and reflect the true state after each action.

* **Refactor**
  * Response constructors simplified to explicit bookmarked/unbookmarked and liked/unliked variants.
  * Data-access behavior adjusted to return deletion results, enabling clearer toggle logic and fewer ambiguous outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->