### PR TITLE
[전남대 3팀_BE] 7차 코드 리뷰

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 	implementation 'org.apache.commons:commons-text:1.12.0'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'software.amazon.awssdk:s3:2.20.26'
 }
 

--- a/src/main/java/com/starterpack/auth/kakao/KakaoApiClient.java
+++ b/src/main/java/com/starterpack/auth/kakao/KakaoApiClient.java
@@ -2,17 +2,27 @@ package com.starterpack.auth.kakao;
 
 import com.starterpack.auth.dto.KakaoTokenResponseDto;
 import com.starterpack.auth.dto.KakaoUserInfoResponseDto;
+import com.starterpack.exception.KakaoAuthException;
+import com.starterpack.exception.KakaoServerException;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
 
 @Component
 @RequiredArgsConstructor
 public class KakaoApiClient {
+
+    private static final int CONNECTION_TIMEOUT_MS = 5000;  // 5초
+    private static final int READ_TIMEOUT_MS = 10000;
+
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String clientId;
     @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
@@ -21,6 +31,18 @@ public class KakaoApiClient {
     private String tokenUri;
     @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
     private String userInfoUri;
+
+    private final RestClient restClient;
+
+    public KakaoApiClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofMillis(CONNECTION_TIMEOUT_MS));
+        requestFactory.setReadTimeout(Duration.ofMillis(READ_TIMEOUT_MS));
+
+        this.restClient = RestClient.builder()
+                .requestFactory(requestFactory)
+                .build();
+    }
 
     /**
      * 인가 코드를 사용하여 카카오로부터 액세스 토큰을 받아옵니다.
@@ -32,24 +54,50 @@ public class KakaoApiClient {
         formData.add("redirect_uri", redirectUri);
         formData.add("code", code);
 
-        return WebClient.create()
-                .post().uri(tokenUri)
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .bodyValue(formData)
-                .retrieve()
-                .bodyToMono(KakaoTokenResponseDto.class)
-                .block();
+        try {
+            return restClient.post()
+                    .uri(tokenUri)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(formData)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                        throw new KakaoAuthException(
+                                "카카오 토큰 발급 실패 - 응답 코드: " + response.getStatusCode()
+                        );
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                        throw new KakaoServerException(
+                                "카카오 서버 오류 - 응답 코드: " + response.getStatusCode()
+                        );
+                    })
+                    .body(KakaoTokenResponseDto.class);
+        } catch (ResourceAccessException e) {
+            throw new KakaoServerException("카카오 서버 연결 실패 (타임아웃 또는 네트워크 오류)");
+        }
     }
 
     /**
      * 액세스 토큰을 사용하여 카카오 API로부터 사용자 정보를 받아옵니다.
      */
     public KakaoUserInfoResponseDto fetchUserInfo(String accessToken) {
-        return WebClient.create()
-                .get().uri(userInfoUri)
-                .headers(header -> header.setBearerAuth(accessToken))
-                .retrieve()
-                .bodyToMono(KakaoUserInfoResponseDto.class)
-                .block();
+        try {
+            return restClient.get()
+                    .uri(userInfoUri)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, (request, response) -> {
+                        throw new KakaoAuthException(
+                                "카카오 사용자 정보 조회 실패 - 응답 코드: " + response.getStatusCode()
+                        );
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, (request, response) -> {
+                        throw new KakaoServerException(
+                                "카카오 서버 오류 - 응답 코드: " + response.getStatusCode()
+                        );
+                    })
+                    .body(KakaoUserInfoResponseDto.class);
+        } catch (ResourceAccessException e) {
+            throw new KakaoServerException("카카오 서버 연결 실패 (타임아웃 또는 네트워크 오류)");
+        }
     }
 }

--- a/src/main/java/com/starterpack/auth/service/AuthService.java
+++ b/src/main/java/com/starterpack/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import com.starterpack.auth.jwt.JwtTokenUtil;
 import com.starterpack.auth.kakao.KakaoApiClient;
 import com.starterpack.exception.BusinessException;
 import com.starterpack.auth.dto.LocalSignUpRequestDto;
+import com.starterpack.exception.KakaoAuthException;
 import com.starterpack.member.dto.MemberCreationRequestDto;
 import com.starterpack.member.dto.MemberResponseDto;
 import com.starterpack.member.entity.Member;
@@ -120,7 +121,13 @@ public class AuthService {
     public TokenResponseDto kakaoLogin(String code) {
         //  Kakao Api Client를 통해 액세스 토큰 및 사용자 정보 조회
         KakaoTokenResponseDto kakaoToken = kakaoApiClient.fetchAccessToken(code);
+        if (kakaoToken == null) {
+            throw new KakaoAuthException("카카오 토큰 발급 실패: 응답 본문이 비어있음");
+        }
         KakaoUserInfoResponseDto userInfo = kakaoApiClient.fetchUserInfo(kakaoToken.accessToken());
+        if (userInfo == null) {
+            throw new KakaoAuthException("사용자 정보 조회 실패: 응답 본문이 비어있음");
+        }
 
         // userInfo를 토대로 MemberCreationRequestDto 생성
         MemberCreationRequestDto creationRequest = MemberCreationRequestDto.fromKakao(userInfo);

--- a/src/main/java/com/starterpack/config/SecurityConfig.java
+++ b/src/main/java/com/starterpack/config/SecurityConfig.java
@@ -109,7 +109,8 @@ public class SecurityConfig {
                                 "/api/products", "/api/products/**",
                                 "/api/categories", // 카테고리 조회 GET 요청
                                 "/api/feeds/*/likes",
-                                "/api/starterPack/packs/*/likes"
+                                "/api/starterPack/packs/*/likes",
+                                "/api/members/*/mypage" // 마이페이지 조회
                         ).permitAll()
                         .requestMatchers(API_PUBLIC_URLS).permitAll()
                         .requestMatchers(COMMON_PUBLIC_URLS).permitAll()

--- a/src/main/java/com/starterpack/exception/ErrorCode.java
+++ b/src/main/java/com/starterpack/exception/ErrorCode.java
@@ -101,6 +101,13 @@ public enum ErrorCode {
     INVALID_FILE_PATH(HttpStatus.BAD_REQUEST,
             "S3_004",
             "유효하지 않은 파일 경로입니다."),
+    //Kakao
+    KAKAO_AUTH_ERROR(HttpStatus.BAD_REQUEST,
+            "K001",
+            "카카오 인증에 실패했습니다."),
+    KAKAO_SERVER_ERROR(HttpStatus.SERVICE_UNAVAILABLE,
+            "K002",
+            "카카오 서버와 통신에 문제가 발생했습니다."),
 
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "FC001", "해당하는 댓글을 찾을 수 없습니다."),
     COMMENT_ALREADY_DELETED(HttpStatus.CONFLICT, "FC002", "이미 삭제된 댓글입니다.");

--- a/src/main/java/com/starterpack/exception/KakaoAuthException.java
+++ b/src/main/java/com/starterpack/exception/KakaoAuthException.java
@@ -1,0 +1,11 @@
+package com.starterpack.exception;
+
+public class KakaoAuthException extends BusinessException {
+    public KakaoAuthException() {
+        super(ErrorCode.KAKAO_AUTH_ERROR);
+    }
+
+    public KakaoAuthException(String detailMessage) {
+        super(ErrorCode.KAKAO_AUTH_ERROR, detailMessage);
+    }
+}

--- a/src/main/java/com/starterpack/exception/KakaoServerException.java
+++ b/src/main/java/com/starterpack/exception/KakaoServerException.java
@@ -1,0 +1,11 @@
+package com.starterpack.exception;
+
+public class KakaoServerException extends BusinessException {
+    public KakaoServerException() {
+        super(ErrorCode.KAKAO_SERVER_ERROR);
+    }
+
+    public KakaoServerException(String detailMessage) {
+        super(ErrorCode.KAKAO_SERVER_ERROR, detailMessage);
+    }
+}

--- a/src/main/java/com/starterpack/feed/dto/FeedBookmarkResponseDto.java
+++ b/src/main/java/com/starterpack/feed/dto/FeedBookmarkResponseDto.java
@@ -3,7 +3,14 @@ package com.starterpack.feed.dto;
 public record FeedBookmarkResponseDto(
         Boolean isBookmarked
 ) {
-    public static FeedBookmarkResponseDto of(Boolean isBookmarked) {
-        return new FeedBookmarkResponseDto(isBookmarked);
+    private static final FeedBookmarkResponseDto BOOKMARKED = new FeedBookmarkResponseDto(true);
+    private static final FeedBookmarkResponseDto UNBOOKMARKED = new FeedBookmarkResponseDto(false);
+
+    public static FeedBookmarkResponseDto bookmarked() {
+        return BOOKMARKED;
+    }
+
+    public static FeedBookmarkResponseDto unbookmarked() {
+        return UNBOOKMARKED;
     }
 }

--- a/src/main/java/com/starterpack/feed/dto/FeedLikeResponseDto.java
+++ b/src/main/java/com/starterpack/feed/dto/FeedLikeResponseDto.java
@@ -4,7 +4,11 @@ public record FeedLikeResponseDto(
         Long likeCount,
         Boolean isLiked
 ) {
-    public static FeedLikeResponseDto of(Long likeCount, Boolean isLiked) {
-        return new FeedLikeResponseDto(likeCount, isLiked);
+    public static FeedLikeResponseDto liked(Long likeCount) {
+        return new FeedLikeResponseDto(likeCount, true);
+    }
+
+    public static FeedLikeResponseDto unliked(Long likeCount) {
+        return new FeedLikeResponseDto(likeCount, false);
     }
 }

--- a/src/main/java/com/starterpack/feed/entity/Feed.java
+++ b/src/main/java/com/starterpack/feed/entity/Feed.java
@@ -128,6 +128,10 @@ public class Feed {
     }
 
     private void setFeedHashtags(List<Hashtag> hashtags) {
+        if (hashtags == null) { //NPE 방지
+            return;
+        }
+
         this.feedHashtags.clear();
         for (int i = 0; i < hashtags.size(); i++) {
             this.feedHashtags.add(new FeedHashtag(this, hashtags.get(i), i));

--- a/src/main/java/com/starterpack/feed/repository/FeedBookmarkRepository.java
+++ b/src/main/java/com/starterpack/feed/repository/FeedBookmarkRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface FeedBookmarkRepository extends JpaRepository<FeedBookmark, Long> {
     boolean existsByFeedAndMember(Feed feed, Member member);
-    void deleteByFeedAndMember(Feed feed, Member member);
+    int deleteByFeedAndMember(Feed feed, Member member);
 
     @Query("SELECT fb.feed.id FROM FeedBookmark fb WHERE fb.member = :member AND fb.feed.id IN :feedIds")
     Set<Long> findFeedIdsByMemberAndFeedIds(@Param("member")Member member, @Param("feedIds") List<Long> feedIds);

--- a/src/main/java/com/starterpack/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/starterpack/feed/repository/FeedLikeRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
     boolean existsByFeedAndMember(Feed feed, Member member);
-    void deleteByFeedAndMember(Feed feed, Member member);
+    int deleteByFeedAndMember(Feed feed, Member member);
 
     @Query("SELECT fl FROM FeedLike fl JOIN FETCH fl.member WHERE fl.feed = :feed")
     Page<FeedLike> findByFeed(@Param("feed") Feed feed, Pageable pageable);

--- a/src/main/java/com/starterpack/feed/repository/FeedRepository.java
+++ b/src/main/java/com/starterpack/feed/repository/FeedRepository.java
@@ -48,4 +48,13 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, JpaSpecificat
     @Modifying
     @Query("UPDATE Feed f SET f.commentCount = f.commentCount - 1 WHERE f.id = :feedId AND f.commentCount > 0")
     void decrementCommentCount(@Param("feedId") Long id);
+
+    // 멤버별 피드 목록 조회
+    @EntityGraph(attributePaths = {"user", "category"})
+    @Query("select f from Feed f where f.user.userId = :memberId order by f.id desc")
+    Page<Feed> findByUserId(@Param("memberId") Long memberId, Pageable pageable);
+
+    // 멤버별 피드 개수 조회
+    @Query("select count(f) from Feed f where f.user.userId = :memberId")
+    long countByUserId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/starterpack/feed/repository/FeedRepository.java
+++ b/src/main/java/com/starterpack/feed/repository/FeedRepository.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface FeedRepository extends JpaRepository<Feed, Long>, JpaSpecificationExecutor<Feed> {
-    @EntityGraph(attributePaths = {"user", "category"})
+    @EntityGraph(attributePaths = {"user", "category", "feedHashtags", "feedHashtags.hashtag"})
     Optional<Feed> findWithDetailsById(@Param("id") Long id);
 
     @Override

--- a/src/main/java/com/starterpack/feed/service/FeedService.java
+++ b/src/main/java/com/starterpack/feed/service/FeedService.java
@@ -183,12 +183,18 @@ public class FeedService {
 
     @Transactional
     public void updateFeedByAdmin(Long feedId, FeedUpdateRequestDto request) {
-        Feed feed = getFeedById(feedId);
+        Feed feed = getFeedByIdWithDetails(feedId);
 
         Category category = getCategory(request.categoryId());
 
-
         feed.update(request.description(), request.imageUrl(), category);
+
+        // 해시태그 처리 로직 추가
+        List<Hashtag> hashtags = hashtagService.resolveHashtags(request.hashtagNames());
+        HashtagUpdateResult result = feed.updateHashtag(hashtags);
+
+        hashtagService.incrementUsageCount(result.added());
+        hashtagService.decrementUsageCount(result.removed());
     }
 
     @Transactional

--- a/src/main/java/com/starterpack/feed/service/FeedService.java
+++ b/src/main/java/com/starterpack/feed/service/FeedService.java
@@ -23,7 +23,6 @@ import com.starterpack.hashtag.service.HashtagService;
 import com.starterpack.member.entity.Member;
 import jakarta.persistence.EntityManager;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -61,7 +60,7 @@ public class FeedService {
                 .hashtags(hashtags)
                 .build();
 
-        hashtagService.incrementUsageCount(new HashSet<>(hashtags));
+        hashtagService.incrementUsageCount(hashtags);
 
         return feedRepository.save(feed);
     }
@@ -135,7 +134,7 @@ public class FeedService {
         feed.validateOwner(member);
 
         List<Hashtag> hashtags = feed.getHashtags();
-        hashtagService.decrementUsageCount(new HashSet<>(hashtags));
+        hashtagService.decrementUsageCount(hashtags);
 
         feedRepository.delete(feed);
     }

--- a/src/main/java/com/starterpack/hashtag/service/HashtagService.java
+++ b/src/main/java/com/starterpack/hashtag/service/HashtagService.java
@@ -3,6 +3,7 @@ package com.starterpack.hashtag.service;
 
 import com.starterpack.hashtag.entity.Hashtag;
 import com.starterpack.hashtag.repository.HashtagRepository;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -42,7 +43,7 @@ public class HashtagService {
     }
 
     @Transactional
-    public void incrementUsageCount(Set<Hashtag> hashtags) {
+    public void incrementUsageCount(Collection<Hashtag> hashtags) {
         if (hashtags == null || hashtags.isEmpty()) return;
 
         Set<Long> ids = hashtags.stream()
@@ -53,7 +54,7 @@ public class HashtagService {
     }
 
     @Transactional
-    public void decrementUsageCount(Set<Hashtag> hashtags) {
+    public void decrementUsageCount(Collection<Hashtag> hashtags) {
         if (hashtags == null || hashtags.isEmpty()) return;
 
         Set<Long> ids = hashtags.stream()

--- a/src/main/java/com/starterpack/member/controller/MyPageController.java
+++ b/src/main/java/com/starterpack/member/controller/MyPageController.java
@@ -1,0 +1,72 @@
+package com.starterpack.member.controller;
+
+import com.starterpack.auth.login.Login;
+import com.starterpack.member.dto.MyPageResponseDto;
+import com.starterpack.member.entity.Member;
+import com.starterpack.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/members")
+@Tag(name = "MyPage", description = "마이페이지 API")
+public class MyPageController {
+    private final MemberService memberService;
+
+    public MyPageController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @GetMapping("/{userId}/mypage")
+    @Operation(
+            summary = "마이페이지 조회", 
+            description = """
+                    특정 회원의 마이페이지 정보를 조회합니다.
+                    
+                    **인증**: 비로그인 사용자도 조회 가능 (토큰 없이도 요청 가능)
+                    
+                    **응답 정보**:
+                    - 사용자 기본 정보 (닉네임, 프로필 이미지, 취미, 한 줄 소개)
+                    - 게시물 통계 (팩 개수, 피드 개수, 전체 게시물 수)
+                    - 작성한 팩 목록 (최신순, 제목, 이미지)
+                    - 작성한 피드 목록 (최신순, 설명, 이미지)
+                    - isMe: 조회한 사람이 본인인지 여부 (로그인 필수)
+                    
+                    **예시**:
+                    - 비로그인 사용자가 조회: isMe = false
+                    - 다른 사용자가 조회: isMe = false
+                    - 본인이 조회: isMe = true
+                    """
+    )
+    @Parameter(
+            name = "userId", 
+            description = "조회할 회원의 ID",
+            required = true,
+            example = "1"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200", 
+                    description = "마이페이지 조회 성공"
+            ),
+            @ApiResponse(
+                    responseCode = "404", 
+                    description = "회원을 찾을 수 없음"
+            )
+    })
+    public ResponseEntity<MyPageResponseDto> getMyPage(
+            @PathVariable Long userId,
+            @Login(required = false) Member currentMember
+    ) {
+        Long currentUserId = (currentMember != null) ? currentMember.getUserId() : null;
+        MyPageResponseDto responseDto = memberService.getMyPage(userId, currentUserId);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+}
+

--- a/src/main/java/com/starterpack/member/dto/MyPageFeedDto.java
+++ b/src/main/java/com/starterpack/member/dto/MyPageFeedDto.java
@@ -1,0 +1,19 @@
+package com.starterpack.member.dto;
+
+import com.starterpack.feed.entity.Feed;
+
+// 마이페이지에서 사용할 간단한 피드 정보
+public record MyPageFeedDto(
+        Long feedId,
+        String description,
+        String imageUrl
+) {
+    public static MyPageFeedDto from(Feed feed) {
+        return new MyPageFeedDto(
+                feed.getId(),
+                feed.getDescription(),
+                feed.getImageUrl()
+        );
+    }
+}
+

--- a/src/main/java/com/starterpack/member/dto/MyPagePackDto.java
+++ b/src/main/java/com/starterpack/member/dto/MyPagePackDto.java
@@ -1,0 +1,19 @@
+package com.starterpack.member.dto;
+
+import com.starterpack.pack.entity.Pack;
+
+// 마이페이지에서 사용할 간단한 팩 정보
+public record MyPagePackDto(
+        Long packId,
+        String name,
+        String mainImageUrl
+) {
+    public static MyPagePackDto from(Pack pack) {
+        return new MyPagePackDto(
+                pack.getId(),
+                pack.getName(),
+                pack.getMainImageUrl()
+        );
+    }
+}
+

--- a/src/main/java/com/starterpack/member/dto/MyPageResponseDto.java
+++ b/src/main/java/com/starterpack/member/dto/MyPageResponseDto.java
@@ -1,0 +1,46 @@
+package com.starterpack.member.dto;
+
+import com.starterpack.member.entity.Member;
+import com.starterpack.pack.entity.Pack;
+import com.starterpack.feed.entity.Feed;
+import java.util.List;
+
+// 마이페이지 응답 DTO
+public record MyPageResponseDto(
+        String nickname,
+        String hobby,
+        String profileImageUrl,
+        String bio,
+        long totalPostCount,
+        long packCount,
+        long feedCount,
+        List<MyPagePackDto> packs,
+        List<MyPageFeedDto> feeds,
+        boolean isMe
+) {
+    public static MyPageResponseDto from(Member member, List<Pack> packs, List<Feed> feeds, boolean isMe) {
+        List<MyPagePackDto> packDtos = packs.stream()
+                .map(MyPagePackDto::from)
+                .toList();
+        
+        List<MyPageFeedDto> feedDtos = feeds.stream()
+                .map(MyPageFeedDto::from)
+                .toList();
+        
+        long totalPostCount = packs.size() + feeds.size();
+        
+        return new MyPageResponseDto(
+                member.getNickname(),
+                member.getHobby(),
+                member.getProfileImageUrl(),
+                member.getBio(),
+                totalPostCount,
+                packs.size(),
+                feeds.size(),
+                packDtos,
+                feedDtos,
+                isMe
+        );
+    }
+}
+

--- a/src/main/java/com/starterpack/member/entity/Member.java
+++ b/src/main/java/com/starterpack/member/entity/Member.java
@@ -56,6 +56,12 @@ public class Member {
     @Column(name = "phone_number", length = 20)
     private String phoneNumber;
 
+    @Column(name = "hobby", length = 200)
+    private String hobby;
+
+    @Column(name = "bio", length = 500)
+    private String bio;
+
     @Column(name = "refresh_token", length = 500)
     private String refreshToken;
 

--- a/src/main/java/com/starterpack/pack/controller/PackController.java
+++ b/src/main/java/com/starterpack/pack/controller/PackController.java
@@ -10,9 +10,11 @@ import com.starterpack.pack.dto.PackCreateRequestDto;
 import com.starterpack.pack.dto.PackDetailResponseDto;
 import com.starterpack.pack.dto.PackLikeResponseDto;
 import com.starterpack.pack.dto.PackLikerResponseDto;
+import com.starterpack.pack.dto.PackRecommendDto;
 import com.starterpack.pack.dto.PackUpdateRequestDto;
 import com.starterpack.pack.entity.Pack;
 import com.starterpack.pack.service.PackCommentService;
+import com.starterpack.pack.service.PackRecommendService;
 import com.starterpack.pack.service.PackService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -41,6 +43,7 @@ public class PackController {
 
     private final PackService packService;
     private final PackCommentService packCommentService;
+    private final PackRecommendService packRecommendService;
 
     @GetMapping("/packs")
     @Operation(summary = "스타터팩 목록 조회", description = "모든 스타터팩 목록을 조회합니다.")
@@ -198,5 +201,15 @@ public class PackController {
     ) {
         PackBookmarkResponseDto responseDto = packService.togglePackBookmark(id, member);
         return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/packs/recommendations")
+    @Operation(
+            summary = "오늘의 추천 스타터팩 Top 3 조회",
+            description = "추천 알고리즘으로 계산된 오늘의 스타터팩 3개를 반환 + 하루에 한 번 자동 갱신됩니다."
+    )
+    @SecurityRequirement(name = "cookieAuth")
+    public ResponseEntity<List<PackRecommendDto>> getTodayRecommendations() {
+        return ResponseEntity.ok(packRecommendService.getTodayTop3());
     }
 }

--- a/src/main/java/com/starterpack/pack/dto/PackBookmarkResponseDto.java
+++ b/src/main/java/com/starterpack/pack/dto/PackBookmarkResponseDto.java
@@ -3,7 +3,14 @@ package com.starterpack.pack.dto;
 public record PackBookmarkResponseDto(
         Boolean isBookmarked
 ) {
-    public static PackBookmarkResponseDto of(Boolean isBookmarked) {
-        return new PackBookmarkResponseDto(isBookmarked);
+    private static final PackBookmarkResponseDto BOOKMARKED = new PackBookmarkResponseDto(true);
+    private static final PackBookmarkResponseDto UNBOOKMARKED = new PackBookmarkResponseDto(false);
+
+    public static PackBookmarkResponseDto bookmarked() {
+        return BOOKMARKED;
+    }
+
+    public static PackBookmarkResponseDto unbookmarked() {
+        return UNBOOKMARKED;
     }
 }

--- a/src/main/java/com/starterpack/pack/dto/PackLikeResponseDto.java
+++ b/src/main/java/com/starterpack/pack/dto/PackLikeResponseDto.java
@@ -4,7 +4,11 @@ public record PackLikeResponseDto(
         Integer likeCount,
         Boolean isLiked
 ) {
-    public static PackLikeResponseDto of(Integer likeCount, Boolean isLiked) {
-        return new PackLikeResponseDto(likeCount, isLiked);
+    public static PackLikeResponseDto liked(Integer likeCount) {
+        return new PackLikeResponseDto(likeCount, true);
+    }
+
+    public static PackLikeResponseDto unliked(Integer likeCount) {
+        return new PackLikeResponseDto(likeCount, false);
     }
 }

--- a/src/main/java/com/starterpack/pack/dto/PackRecommendDto.java
+++ b/src/main/java/com/starterpack/pack/dto/PackRecommendDto.java
@@ -1,0 +1,25 @@
+package com.starterpack.pack.dto;
+
+import com.starterpack.pack.entity.Pack;
+
+public record PackRecommendDto(
+        Long id,
+        String name,
+        Integer price,
+        String mainImageUrl,
+        Integer likeCount,
+        Integer bookmarkCount,
+        double score
+) {
+    public static PackRecommendDto from(Pack pack, double score) {
+        return new PackRecommendDto(
+                pack.getId(),
+                pack.getName(),
+                pack.getPrice(),
+                pack.getMainImageUrl(),
+                pack.getPackLikeCount(),
+                pack.getPackBookmarkCount(),
+                score
+        );
+    }
+}

--- a/src/main/java/com/starterpack/pack/entity/Pack.java
+++ b/src/main/java/com/starterpack/pack/entity/Pack.java
@@ -62,6 +62,7 @@ public class Pack {
 
     @org.hibernate.annotations.BatchSize(size = 100)
     @OneToMany(mappedBy = "pack", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("tagOrder ASC")
     private List<PackHashtag> packHashtags = new ArrayList<>();
 
     public void changeName(String name) {
@@ -186,6 +187,10 @@ public class Pack {
     }
 
     private void setPackHashtags(List<Hashtag> hashtags) {
+        if (hashtags == null) {
+            return;
+        }
+
         this.packHashtags.clear();
         for (int i = 0; i < hashtags.size(); i++) {
             this.packHashtags.add(new PackHashtag(this, hashtags.get(i), i));

--- a/src/main/java/com/starterpack/pack/entity/PackLike.java
+++ b/src/main/java/com/starterpack/pack/entity/PackLike.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -16,12 +17,15 @@ import lombok.Getter;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
-@Table(name = "pack_like", uniqueConstraints = {
-        @UniqueConstraint(
-                name = "uk_pack_like_member",
-                columnNames = {"pack_id", "member_id"}
-        )
-})
+@Table(
+        name = "pack_like",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_pack_like_member", columnNames = {"pack_id", "member_id"})
+        },
+        indexes = {
+                @Index(name = "idx_pack_like_pack_created_at", columnList = "pack_id, created_at")
+        }
+)
 @Getter
 public class PackLike {
     @Id

--- a/src/main/java/com/starterpack/pack/repository/PackBookmarkRepository.java
+++ b/src/main/java/com/starterpack/pack/repository/PackBookmarkRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PackBookmarkRepository extends JpaRepository<PackBookmark, Long> {
     boolean existsByPackAndMember(Pack pack, Member member);
-    void deleteByPackAndMember(Pack pack, Member member);
+    int deleteByPackAndMember(Pack pack, Member member);
 }

--- a/src/main/java/com/starterpack/pack/repository/PackLikeRepository.java
+++ b/src/main/java/com/starterpack/pack/repository/PackLikeRepository.java
@@ -12,7 +12,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface PackLikeRepository extends JpaRepository<PackLike, Long> {
     boolean existsByPackAndMember(Pack pack, Member member);
-    void deleteByPackAndMember(Pack pack, Member member);
+    int deleteByPackAndMember(Pack pack, Member member);
 
     @Query("SELECT pl FROM PackLike pl JOIN FETCH  pl.member WHERE pl.pack = :pack")
     Page<PackLike> findByPack(@Param("pack") Pack pack, Pageable pageable);

--- a/src/main/java/com/starterpack/pack/repository/PackRepository.java
+++ b/src/main/java/com/starterpack/pack/repository/PackRepository.java
@@ -65,6 +65,26 @@ public interface PackRepository extends JpaRepository<Pack, Long> {
     """)
     void decrementCommentCount(@Param("id") Long id);
 
+    // 멤버별 팩 목록 조회
+
+    @Query("""
+        select distinct p
+        from Pack p
+        left join fetch p.items
+        left join fetch p.category
+        where p.member.userId = :memberId
+        order by p.id desc
+    """)
+    List<Pack> findByMemberId(@Param("memberId") Long memberId);
+
+    // 멤버별 팩 개수 조회
+    @Query("""
+        select count(p)
+        from Pack p
+        where p.member.userId = :memberId
+    """)
+    long countByMemberId(@Param("memberId") Long memberId);
+
     // ── N+1 제거용: 배치 집계 (IN + GROUP BY) ──
 
     @Query("""

--- a/src/main/java/com/starterpack/pack/repository/PackRepository.java
+++ b/src/main/java/com/starterpack/pack/repository/PackRepository.java
@@ -1,6 +1,7 @@
 package com.starterpack.pack.repository;
 
 import com.starterpack.pack.entity.Pack;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -10,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PackRepository extends JpaRepository<Pack, Long> {
+
     @Override
     @EntityGraph(attributePaths = {"items", "category", "member"})
     List<Pack> findAll();
@@ -55,25 +57,63 @@ public interface PackRepository extends JpaRepository<Pack, Long> {
     void incrementCommentCount(@Param("id") Long id);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE Pack p SET p.packCommentCount = CASE WHEN p.packCommentCount > 0 THEN p.packCommentCount - 1 ELSE 0 END WHERE p.id = :id")
+    @Query("""
+        UPDATE Pack p
+        SET p.packCommentCount =
+            CASE WHEN p.packCommentCount > 0 THEN p.packCommentCount - 1 ELSE 0 END
+        WHERE p.id = :id
+    """)
     void decrementCommentCount(@Param("id") Long id);
 
-    // 멤버별 팩 목록 조회
-    @Query("""
-        select distinct p
-        from Pack p
-        left join fetch p.items
-        left join fetch p.category
-        where p.member.userId = :memberId
-        order by p.id desc
-    """)
-    List<Pack> findByMemberId(@Param("memberId") Long memberId);
+    // ── N+1 제거용: 배치 집계 (IN + GROUP BY) ──
 
-    // 멤버별 팩 개수 조회
     @Query("""
-        select count(p)
-        from Pack p
-        where p.member.userId = :memberId
+      select pl.pack.id, count(pl)
+      from com.starterpack.pack.entity.PackLike pl
+      where pl.pack.id in :ids and pl.createdAt >= :from
+      group by pl.pack.id
     """)
-    long countByMemberId(@Param("memberId") Long memberId);
+    List<Object[]> countLikesSinceIn(@Param("ids") List<Long> ids,
+            @Param("from") LocalDateTime from);
+
+    @Query("""
+      select pl.pack.id, count(pl)
+      from com.starterpack.pack.entity.PackLike pl
+      where pl.pack.id in :ids and pl.createdAt >= :from and pl.createdAt < :to
+      group by pl.pack.id
+    """)
+    List<Object[]> countLikesBetweenIn(@Param("ids") List<Long> ids,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to);
+
+    @Query("""
+      select pl.pack.id, max(pl.createdAt)
+      from com.starterpack.pack.entity.PackLike pl
+      where pl.pack.id in :ids
+      group by pl.pack.id
+    """)
+    List<Object[]> findLastLikeTimeIn(@Param("ids") List<Long> ids);
+
+    @Query("""
+      select pl.pack.id, pl.createdAt
+      from com.starterpack.pack.entity.PackLike pl
+      where pl.pack.id in :ids and pl.createdAt >= :from
+      order by pl.pack.id asc, pl.createdAt desc
+    """)
+    List<Object[]> findLikeTimesSinceIn(@Param("ids") List<Long> ids,
+            @Param("from") LocalDateTime from);
+
+    // 윈도우 함수로 pack별 최신 N개 타임스탬프
+    @Query(value = """
+      SELECT pack_id, created_at
+      FROM (
+        SELECT pl.pack_id, pl.created_at,
+               ROW_NUMBER() OVER (PARTITION BY pl.pack_id ORDER BY pl.created_at DESC) AS rn
+        FROM pack_like pl
+        WHERE pl.pack_id IN (:ids)
+      ) t
+      WHERE t.rn <= :n
+      ORDER BY pack_id, created_at DESC
+    """, nativeQuery = true)
+    List<Object[]> findRecentLikeTimesTopNIn(@Param("ids") List<Long> ids, @Param("n") int n);
 }

--- a/src/main/java/com/starterpack/pack/repository/PackRepository.java
+++ b/src/main/java/com/starterpack/pack/repository/PackRepository.java
@@ -57,4 +57,23 @@ public interface PackRepository extends JpaRepository<Pack, Long> {
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Pack p SET p.packCommentCount = CASE WHEN p.packCommentCount > 0 THEN p.packCommentCount - 1 ELSE 0 END WHERE p.id = :id")
     void decrementCommentCount(@Param("id") Long id);
+
+    // 멤버별 팩 목록 조회
+    @Query("""
+        select distinct p
+        from Pack p
+        left join fetch p.items
+        left join fetch p.category
+        where p.member.userId = :memberId
+        order by p.id desc
+    """)
+    List<Pack> findByMemberId(@Param("memberId") Long memberId);
+
+    // 멤버별 팩 개수 조회
+    @Query("""
+        select count(p)
+        from Pack p
+        where p.member.userId = :memberId
+    """)
+    long countByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/starterpack/pack/service/PackRecommendService.java
+++ b/src/main/java/com/starterpack/pack/service/PackRecommendService.java
@@ -1,0 +1,246 @@
+package com.starterpack.pack.service;
+
+import com.starterpack.pack.dto.PackRecommendDto;
+import com.starterpack.pack.entity.Pack;
+import com.starterpack.pack.repository.PackRepository;
+import java.sql.Timestamp;
+import java.time.*;
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PackRecommendService {
+
+    private final PackRepository packRepository;
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+    private static final int    N_LIKE_TIMES = 200;      // decayAverage용 최근 N개
+    private static final double HALF_LIFE_HOURS = 24.0;  // 감쇠 반감기(시간)
+
+    public List<PackRecommendDto> getTodayTop3() {
+        List<Pack> packs = packRepository.findAll();
+        if (packs.isEmpty()) return List.of();
+
+        LocalDateTime nowLdt = LocalDateTime.now(ZONE);
+        Instant now = nowLdt.atZone(ZONE).toInstant();
+        LocalDateTime from24h = nowLdt.minusHours(24);
+        LocalDateTime from48h = nowLdt.minusHours(48);
+        LocalDateTime from7d  = nowLdt.minusDays(7);
+        LocalDate today = nowLdt.toLocalDate();
+        LocalDateTime from60d = nowLdt.minusDays(60);
+
+        // ── 한 번에 packIds 수집
+        List<Long> ids = packs.stream().map(Pack::getId).toList();
+
+        // ── 배치 집계 (각 1쿼리)
+        Map<Long, Long> L24hMap     = toLongMap(packRepository.countLikesSinceIn(ids, from24h));
+        Map<Long, Long> L7dMap      = toLongMap(packRepository.countLikesSinceIn(ids, from7d));
+        Map<Long, Long> Lprev24hMap = toLongMap(packRepository.countLikesBetweenIn(ids, from48h, from24h));
+        Map<Long, LocalDateTime> lastLikeMap = toTimeMap(packRepository.findLastLikeTimeIn(ids));
+        Map<Long, List<LocalDateTime>> likeTimesSinceMap =
+                toTimeListMap(packRepository.findLikeTimesSinceIn(ids, from60d));
+        Map<Long, List<LocalDateTime>> recentLikeTopNMap =
+                toTimeListMap(packRepository.findRecentLikeTimesTopNIn(ids, N_LIKE_TIMES));
+
+        record F(Pack p, long Ltotal, long L24h, long L7d, long Lprev24h,
+                 long streakDays, long hoursSinceLastLike, List<Instant> likeTimes) {}
+
+        List<F> feats = new ArrayList<>(packs.size());
+        for (Pack p : packs) {
+            long pid = p.getId();
+
+            long Ltotal   = Optional.ofNullable(p.getPackLikeCount()).orElse(0);
+            long L24h     = L24hMap.getOrDefault(pid, 0L);
+            long L7d      = L7dMap.getOrDefault(pid, 0L);
+            long Lprev24h = Lprev24hMap.getOrDefault(pid, 0L);
+
+            long hoursSinceLastLike = Optional.ofNullable(lastLikeMap.get(pid))
+                    .map(t -> Duration.between(t.atZone(ZONE).toInstant(), now).toHours())
+                    .map(h -> Math.max(0, h))
+                    .orElse(Long.MAX_VALUE);
+
+            List<Instant> likeTimes = recentLikeTopNMap.getOrDefault(pid, List.of())
+                    .stream().map(t -> t.atZone(ZONE).toInstant()).toList();
+
+            long streakDays = computeStreakDays(
+                    likeTimesSinceMap.getOrDefault(pid, List.of())
+                            .stream().map(LocalDateTime::toLocalDate).toList(),
+                    today
+            );
+
+            feats.add(new F(p, Ltotal, L24h, L7d, Lprev24h, streakDays, hoursSinceLastLike, likeTimes));
+        }
+
+        // ── 퍼센타일(5/95)
+        List<Long> arrLtotal = feats.stream().map(f -> f.Ltotal).toList();
+        List<Long> arrL24h   = feats.stream().map(f -> f.L24h).toList();
+        List<Double>arrRate  = feats.stream().map(f -> f.L7d > 0 ? (double) f.L24h / (double) f.L7d : 0.0).toList();
+        List<Long> arrAccel  = feats.stream().map(f -> Math.max(0, f.L24h - f.Lprev24h)).toList();
+        List<Long> arrStreak = feats.stream().map(f -> f.streakDays).toList();
+
+        double p5_Ltotal   = percentileLong(arrLtotal, 0.05);
+        double p95_Ltotal  = percentileLong(arrLtotal, 0.95);
+        double p5_L24h     = percentileLong(arrL24h,   0.05);
+        double p95_L24h    = percentileLong(arrL24h,   0.95);
+        double p5_rate     = percentileDouble(arrRate,  0.05);
+        double p95_rate    = percentileDouble(arrRate,  0.95);
+        double p5_accel    = percentileLong(arrAccel,   0.05);
+        double p95_accel   = percentileLong(arrAccel,   0.95);
+        double p5_streak   = percentileLong(arrStreak,  0.05);
+        double p95_streak  = percentileLong(arrStreak,  0.95);
+
+        // ── 점수 계산
+        record S(Pack p, double score) {}
+        List<S> scored = feats.stream().map(f -> {
+            double score = computeScoreWithAvgDecay(
+                    f.Ltotal, f.L24h, f.L7d, f.Lprev24h,
+                    f.streakDays,
+                    p5_Ltotal, p95_Ltotal,
+                    p5_L24h,  p95_L24h,
+                    p5_rate,  p95_rate,
+                    p5_accel, p95_accel,
+                    p5_streak,p95_streak,
+                    HALF_LIFE_HOURS,
+                    f.likeTimes, now
+            );
+            return new S(f.p, score);
+        }).collect(Collectors.toList());
+
+        // ── Top3
+        return scored.stream()
+                .sorted(Comparator.comparingDouble(S::score).reversed())
+                .limit(3)
+                .map(s -> PackRecommendDto.from(s.p, s.score))
+                .toList();
+    }
+
+    // ───────────── LikeScore 로직 ─────────────
+
+    private static double computeScoreWithAvgDecay(
+            long Ltotal, long L24h, long L7d, long Lprev24h,
+            long streakDays,
+            double p5_Ltotal, double p95_Ltotal,
+            double p5_L24h,  double p95_L24h,
+            double p5_rate,  double p95_rate,
+            double p5_accel, double p95_accel,
+            double p5_streak,double p95_streak,
+            double halfLifeHours,
+            List<Instant> likeTimes, Instant now
+    ) {
+        double rate  = (L7d > 0) ? ((double)L24h / (double)L7d) : 0.0;
+        long accel   = Math.max(0, L24h - Lprev24h);
+
+        double s_total  = lnorm(Ltotal, p5_Ltotal, p95_Ltotal);
+        double s_24h    = lnorm(L24h,   p5_L24h,   p95_L24h);
+        double s_rate   = rnorm(rate,   p5_rate,   p95_rate);
+        double s_accel  = lnorm(accel,  p5_accel,  p95_accel);
+        double s_streak = rnorm(streakDays, p5_streak, p95_streak);
+
+        double raw = 0.35 * s_total
+                + 0.35 * s_24h
+                + 0.15 * s_rate
+                + 0.10 * s_accel
+                + 0.05 * s_streak;
+
+        double Davg = decayAverage(likeTimes, now, halfLifeHours);
+        return raw * Davg;
+    }
+
+    private static double rnorm(double x, double p5, double p95) {
+        if (p95 - p5 < 1e-9) return 0.0;
+        return Math.max(0, Math.min(1, (x - p5) / (p95 - p5)));
+    }
+
+    private static double lnorm(double x, double p5, double p95) {
+        if (x <= p5) return 0.0;
+        if (x >= p95) return 1.0;
+        return (Math.log(x + 1) - Math.log(p5 + 1)) / (Math.log(p95 + 1) - Math.log(p5 + 1));
+    }
+
+    // ← 연속시간(소수)로 계산하도록 개선 (반감기 해석 정확)
+    private static double decayAverage(List<Instant> likeTimes, Instant now, double halfLifeHours) {
+        if (likeTimes == null || likeTimes.isEmpty()) return 0.0;
+        if (halfLifeHours <= 0.0) return 1.0;
+        double lambda = Math.log(2.0) / halfLifeHours;
+        double sum = 0.0;
+        for (Instant t : likeTimes) {
+            double dtHours = Math.max(0.0, Duration.between(t, now).toMillis() / 3600000.0);
+            sum += Math.exp(-lambda * dtHours);
+        }
+        return sum / likeTimes.size();
+    }
+
+    private static long computeStreakDays(List<LocalDate> dates, LocalDate today) {
+        if (dates.isEmpty()) return 0L;
+        Set<LocalDate> set = new HashSet<>(dates);
+        long streak = 0;
+        LocalDate cur = today;
+        while (set.contains(cur)) {
+            streak++;
+            cur = cur.minusDays(1);
+        }
+        return streak;
+    }
+
+    private static double percentileLong(List<Long> data, double q) {
+        if (data.isEmpty()) return 0.0;
+        List<Long> sorted = new ArrayList<>(data);
+        sorted.sort(Long::compare);
+        int idx = (int) Math.floor(q * (sorted.size() - 1));
+        idx = Math.max(0, Math.min(idx, sorted.size() - 1));
+        return sorted.get(idx);
+    }
+
+    private static double percentileDouble(List<Double> data, double q) {
+        if (data.isEmpty()) return 0.0;
+        List<Double> sorted = new ArrayList<>(data);
+        sorted.sort(Double::compare);
+        int idx = (int) Math.floor(q * (sorted.size() - 1));
+        idx = Math.max(0, Math.min(idx, sorted.size() - 1));
+        return sorted.get(idx);
+    }
+
+    // ── 공용 변환기: 네이티브 쿼리 Timestamp 안전 변환 ──
+    private static LocalDateTime toLocalDateTime(Object v) {
+        if (v == null) return null;
+        if (v instanceof LocalDateTime ldt) return ldt;
+        if (v instanceof Timestamp ts) return ts.toLocalDateTime();
+        if (v instanceof java.util.Date d) return LocalDateTime.ofInstant(d.toInstant(), ZONE);
+        if (v instanceof Long epochMillis) return LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), ZONE);
+        throw new IllegalStateException("Unsupported timestamp type: " + v.getClass());
+    }
+
+    // ── 작은 변환 유틸 ──
+    private static Map<Long, Long> toLongMap(List<Object[]> rows) {
+        Map<Long, Long> m = new HashMap<>();
+        for (Object[] r : rows) {
+            m.put(((Number) r[0]).longValue(), ((Number) r[1]).longValue());
+        }
+        return m;
+    }
+
+    private static Map<Long, LocalDateTime> toTimeMap(List<Object[]> rows) {
+        Map<Long, LocalDateTime> m = new HashMap<>();
+        for (Object[] r : rows) {
+            m.put(((Number) r[0]).longValue(), toLocalDateTime(r[1]));
+        }
+        return m;
+    }
+
+    private static Map<Long, List<LocalDateTime>> toTimeListMap(List<Object[]> rows) {
+        Map<Long, List<LocalDateTime>> m = new HashMap<>();
+        for (Object[] r : rows) {
+            Long id = ((Number) r[0]).longValue();
+            LocalDateTime ts = toLocalDateTime(r[1]);
+            if (ts != null) {
+                m.computeIfAbsent(id, k -> new ArrayList<>()).add(ts);
+            }
+        }
+        return m;
+    }
+}

--- a/src/main/java/com/starterpack/pack/service/PackService.java
+++ b/src/main/java/com/starterpack/pack/service/PackService.java
@@ -195,36 +195,34 @@ public class PackService {
     public PackLikeResponseDto togglePackLike(Long id, Member member) {
         Pack pack = findPackById(id);
 
-        boolean exists = packLikeRepository.existsByPackAndMember(pack, member);
+        int deletedRows = packLikeRepository.deleteByPackAndMember(pack, member);
 
-        if (exists) {
-            packLikeRepository.deleteByPackAndMember(pack, member);
+        if (deletedRows > 0) {
             packRepository.decrementLikeCount(id);
+            entityManager.refresh(pack);
+            return PackLikeResponseDto.unliked(pack.getPackLikeCount());
         } else {
             packLikeRepository.save(new PackLike(pack, member));
             packRepository.incrementLikeCount(id);
+            entityManager.refresh(pack);
+            return PackLikeResponseDto.liked(pack.getPackLikeCount());
         }
-
-        entityManager.refresh(pack);
-
-        return PackLikeResponseDto.of(pack.getPackLikeCount(), !exists);
     }
 
     @Transactional
     public PackBookmarkResponseDto togglePackBookmark(Long id, Member member) {
         Pack pack = findPackById(id);
 
-        boolean exists = packBookmarkRepository.existsByPackAndMember(pack, member);
+        int deletedRows = packBookmarkRepository.deleteByPackAndMember(pack, member);
 
-        if (exists) {
-            packBookmarkRepository.deleteByPackAndMember(pack, member);
+        if (deletedRows > 0) {
             packRepository.decrementPackBookmarkCount(id);
+            return PackBookmarkResponseDto.unbookmarked();
         } else {
             packBookmarkRepository.save(new PackBookmark(pack, member));
             packRepository.incrementPackBookmarkCount(id);
+            return PackBookmarkResponseDto.bookmarked();
         }
-
-        return PackBookmarkResponseDto.of(!exists);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/starterpack/pack/service/PackService.java
+++ b/src/main/java/com/starterpack/pack/service/PackService.java
@@ -104,7 +104,7 @@ public class PackService {
             }
         }
 
-        hashtagService.incrementUsageCount(new HashSet<>(hashtags));
+        hashtagService.incrementUsageCount(hashtags);
 
         return packRepository.save(pack);
     }
@@ -168,7 +168,7 @@ public class PackService {
         validatePackOwnership(pack, member);
 
         List<Hashtag> hashtags = pack.getHashtags();
-        hashtagService.decrementUsageCount(new HashSet<>(hashtags));
+        hashtagService.decrementUsageCount(hashtags);
 
         packRepository.delete(pack);
     }

--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -37,6 +37,8 @@ CREATE TABLE member (
   birth_date         DATE,
   gender             VARCHAR(10),
   phone_number       VARCHAR(20),
+  hobby              VARCHAR(200),
+  bio                VARCHAR(500),
   refresh_token      VARCHAR(500),
   created_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/src/main/resources/schema-mysql.sql
+++ b/src/main/resources/schema-mysql.sql
@@ -96,7 +96,7 @@ CREATE TABLE pack (
   main_image_url      VARCHAR(1000),
   description         LONGTEXT,
   created_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+  updated_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
   KEY idx_pack_category (category_id),
   KEY idx_pack_member (member_id),
@@ -117,15 +117,15 @@ CREATE TABLE pack (
 ) ENGINE=InnoDB;
 
 -- ------------------------------------------------------------
--- 6) 팩 아이템 (PackItem) - 새로운 구조
+-- 6) 팩 아이템 (PackItem)
 -- ------------------------------------------------------------
 CREATE TABLE pack_item (
     id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     pack_id     BIGINT UNSIGNED NOT NULL,
     name        VARCHAR(200)    NOT NULL,
-    link_url    VARCHAR(1000)    NULL,
+    link_url    VARCHAR(1000)   NULL,
     description VARCHAR(1000)   NULL,
-    image_url   VARCHAR(1000)    NULL,
+    image_url   VARCHAR(1000)   NULL,
     created_at  TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at  TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
@@ -136,20 +136,21 @@ CREATE TABLE pack_item (
             ON UPDATE CASCADE
             ON DELETE CASCADE
 ) ENGINE=InnoDB;
+
 -- ------------------------------------------------------------
 -- 5) 사용자 피드 (Feed)
 -- ------------------------------------------------------------
 CREATE TABLE feed (
-    id          BIGINT UNSIGNED     NOT NULL AUTO_INCREMENT,
-    user_id     BIGINT UNSIGNED     NOT NULL,
-    description VARCHAR(2000)       NOT NULL,
-    image_url   VARCHAR(500)        NOT NULL,
-    category_id BIGINT UNSIGNED     NOT NULL,
-    like_count  BIGINT     UNSIGNED    NOT NULL DEFAULT 0,
-    bookmark_count  BIGINT UNSIGNED    NOT NULL DEFAULT 0,
-    comment_count BIGINT   UNSIGNED    NOT NULL DEFAULT 0,
-    created_at  TIMESTAMP           NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at  TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    user_id         BIGINT UNSIGNED NOT NULL,
+    description     VARCHAR(2000)   NOT NULL,
+    image_url       VARCHAR(500)    NOT NULL,
+    category_id     BIGINT UNSIGNED NOT NULL,
+    like_count      BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    bookmark_count  BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    comment_count   BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    created_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
     KEY idx_feed_user (user_id),
     KEY idx_feed_category (category_id),
@@ -167,6 +168,7 @@ CREATE TABLE feed (
             ON UPDATE CASCADE
             ON DELETE RESTRICT
 ) ENGINE=InnoDB;
+
 -- ------------------------------------------------------------
 -- 7) 피드 좋아요 (Feed Like)
 -- ------------------------------------------------------------
@@ -189,6 +191,7 @@ CREATE TABLE feed_like (
            ON UPDATE CASCADE
            ON DELETE CASCADE
 ) ENGINE=InnoDB;
+
 -- ------------------------------------------------------------
 -- 8) 피드 북마크 (Feed Bookmark)
 -- ------------------------------------------------------------
@@ -211,6 +214,7 @@ CREATE TABLE feed_bookmark (
            ON UPDATE CASCADE
            ON DELETE CASCADE
 ) ENGINE=InnoDB;
+
 -- ------------------------------------------------------------
 -- 9) 피드 댓글 (Feed Comment)
 -- ------------------------------------------------------------
@@ -246,8 +250,9 @@ CREATE TABLE feed_comment (
     ON UPDATE CASCADE
     ON DELETE CASCADE
 ) ENGINE=InnoDB;
+
 -- ------------------------------------------------------------
--- 10) 팩 좋아요 (Pack Like)
+-- 10) 팩 좋아요 (Pack Like)  ← 옵션 A: 인덱스를 테이블 내부 KEY로 정의
 -- ------------------------------------------------------------
 CREATE TABLE pack_like (
    id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -257,6 +262,7 @@ CREATE TABLE pack_like (
    PRIMARY KEY (id),
    UNIQUE KEY uk_pack_like_member (pack_id, member_id),
    KEY idx_pl_member (member_id),
+   KEY idx_pack_like_pack_created_at (pack_id, created_at),
    CONSTRAINT fk_pl_pack
        FOREIGN KEY (pack_id)
            REFERENCES pack(id)
@@ -268,6 +274,7 @@ CREATE TABLE pack_like (
            ON UPDATE CASCADE
            ON DELETE CASCADE
 ) ENGINE=InnoDB;
+
 -- ------------------------------------------------------------
 -- 11) 팩 북마크 (Pack Bookmark)
 -- ------------------------------------------------------------
@@ -290,6 +297,7 @@ CREATE TABLE pack_bookmark (
            ON UPDATE CASCADE
            ON DELETE CASCADE
 ) ENGINE=InnoDB;
+
 -- ------------------------------------------------------------
 -- 12) 팩 댓글 (Pack Comment)
 -- ------------------------------------------------------------
@@ -319,6 +327,7 @@ CREATE TABLE pack_comment (
     FOREIGN KEY (parent_id) REFERENCES pack_comment(id)
     ON UPDATE CASCADE ON DELETE CASCADE
 ) ENGINE=InnoDB;
+
 -- ------------------------------------------------------------
 -- 13) 해시태그 (Hashtag)
 -- ------------------------------------------------------------
@@ -331,6 +340,7 @@ CREATE TABLE hashtag (
      PRIMARY KEY (id),
      UNIQUE KEY uk_hashtag_name (name)
 ) ENGINE=InnoDB;
+
 -- ------------------------------------------------------------
 -- 14) 피드-해시태그 연관테이블 (feed_hashtag)
 -- ------------------------------------------------------------
@@ -350,6 +360,7 @@ CREATE TABLE feed_hashtag (
               ON UPDATE CASCADE ON DELETE CASCADE,
       CONSTRAINT chk_fh_tag_order CHECK (tag_order >= 0)
 ) ENGINE=InnoDB;
+
 -- ------------------------------------------------------------
 -- 15) 취미 팩-해시태그 연관테이블 (pack_hashtag)
 -- ------------------------------------------------------------
@@ -369,8 +380,9 @@ CREATE TABLE pack_hashtag (
           ON UPDATE CASCADE ON DELETE CASCADE,
   CONSTRAINT chk_ph_tag_order CHECK (tag_order >= 0)
 ) ENGINE=InnoDB;
+
 -- ------------------------------------------------------------
--- (옵션) 조회 최적화용 인덱스 예시.
+-- (옵션) 조회 최적화용 인덱스 예시
 -- ------------------------------------------------------------
 -- 좋아요 순 상품/팩 랭킹
 CREATE INDEX idx_product_like ON product(like_count DESC);

--- a/src/main/resources/templates/admin/feed/detail.html
+++ b/src/main/resources/templates/admin/feed/detail.html
@@ -36,6 +36,15 @@
               <dt>작성자</dt><dd th:text="${feed.user.email}">user@example.com</dd>
               <dt>카테고리</dt><dd th:text="${feed.category != null ? feed.category.name : '미지정'}">카테고리</dd>
               <dt>좋아요 수</dt><dd th:text="${feed.likeCount}">0</dd>
+              <dt>해시태그</dt>
+              <dd>
+                <span th:if="${feed.hashtags != null and !feed.hashtags.isEmpty()}"
+                      th:each="hashtag, iterStat : ${feed.hashtags}">
+                  <span th:text="'#' + ${hashtag.name}">#태그</span>
+                  <span th:if="${!iterStat.last}">, </span>
+                </span>
+                <span th:if="${feed.hashtags == null or feed.hashtags.isEmpty()}" class="text-muted">없음</span>
+              </dd>
               <dt>작성일</dt><dd th:text="${#temporals.format(feed.createdAt, 'yyyy-MM-dd HH:mm:ss')}">2024-01-01 12:00:00</dd>
               <dt>수정일</dt><dd th:text="${#temporals.format(feed.updatedAt, 'yyyy-MM-dd HH:mm:ss')}">2024-01-01 12:00:00</dd>
             </dl>

--- a/src/main/resources/templates/admin/feed/form.html
+++ b/src/main/resources/templates/admin/feed/form.html
@@ -49,6 +49,14 @@
             </select>
           </div>
 
+          <div class="field">
+            <label for="hashtagNames">해시태그 (쉼표로 구분)</label>
+            <input type="text" id="hashtagNames" name="hashtagNames" 
+                   th:value="${isEdit ? #strings.listJoin(feed.hashtags.![name], ', ') : ''}" 
+                   placeholder="예: 해시태그1, 해시태그2, 해시태그3"/>
+            <small class="text-xs text-muted">최대 10개까지 가능합니다.</small>
+          </div>
+
           <div class="btnbar">
             <button type="submit" class="btn btn-primary">저장</button>
             <a th:href="@{/admin/feeds}" class="btn">취소</a>
@@ -58,20 +66,5 @@
     </div>
   </main>
 </div>
-
-
-<template id="product-item-template">
-  <div class="product-item">
-    <div class="product-item-header">
-      <strong class="product-title">상품</strong>
-      <button type="button" class="remove-product-btn">삭제</button>
-    </div>
-    <div class="product-fields">
-      <input type="text" class="product-name" placeholder="상품명" required>
-      <input type="url" class="product-image-url" placeholder="상품 이미지 URL">
-      <textarea class="product-description" placeholder="상품 설명" rows="2"></textarea>
-    </div>
-  </div>
-</template>
 </body>
 </html>

--- a/src/main/resources/templates/admin/packs/form.html
+++ b/src/main/resources/templates/admin/packs/form.html
@@ -114,6 +114,16 @@
                 <textarea id="description" th:field="*{description}" th:classappend="${#fields.hasErrors('description')} ? 'invalid'"></textarea>
                 <div class="error" th:errors="*{description}"></div>
               </div>
+
+              <div class="field">
+                <label for="hashtagNames">해시태그 (쉼표로 구분)</label>
+                <input type="text" id="hashtagNames" name="hashtagNames" 
+                       th:value="${isEdit ? (#strings.listJoin(packDto.hashtagNames, ', ')) : ''}" 
+                       th:classappend="${#fields.hasErrors('hashtagNames')} ? 'invalid'"
+                       placeholder="예: 해시태그1, 해시태그2, 해시태그3"/>
+                <div class="error" th:errors="*{hashtagNames}"></div>
+                <div class="small muted">최대 10개까지 가능합니다.</div>
+              </div>
             </div>
 
             <!-- 우측: PackItem 관리 -->

--- a/src/test/java/com/starterpack/member/service/MemberServiceMyPageTest.java
+++ b/src/test/java/com/starterpack/member/service/MemberServiceMyPageTest.java
@@ -1,0 +1,84 @@
+package com.starterpack.member.service;
+
+import com.starterpack.member.dto.MyPageResponseDto;
+import com.starterpack.member.entity.Member;
+import com.starterpack.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class MemberServiceMyPageTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    /**
+     * 비로그인 사용자가 마이페이지를 조회할 때 isMe가 false인지 확인
+     * - 닉네임, 취미, 한 줄 소개 필드가 정확히 매핑되는지 확인
+     */
+    @Test
+    void testMyPageForAnonymousUser_ReturnsIsMeFalse() {
+        // given
+        Member member = Member.createUser(
+                "test@test.com",
+                "password",
+                "Test Name",
+                "testnick",
+                Member.Provider.EMAIL,
+                "providerId",
+                null,
+                null,
+                null
+        );
+        member.setHobby("독서");
+        member.setBio("한 줄 소개");
+        member = memberRepository.save(member);
+
+        // when - 비로그인 사용자(null)가 마이페이지 조회
+        MyPageResponseDto response = memberService.getMyPage(member.getUserId(), null);
+
+        // then - isMe가 false이고 모든 필드가 정확히 매핑됨
+        assertThat(response).isNotNull();
+        assertThat(response.nickname()).isEqualTo("testnick");
+        assertThat(response.hobby()).isEqualTo("독서");
+        assertThat(response.bio()).isEqualTo("한 줄 소개");
+        assertThat(response.isMe()).isFalse();
+    }
+
+    /**
+     * 본인(userId == currentUserId)이 마이페이지를 조회할 때 isMe가 true인지 확인
+     */
+    @Test
+    void testMyPageForOwner_ReturnsIsMeTrue() {
+        // given
+        Member member = Member.createUser(
+                "test2@test.com",
+                "password",
+                "Test Name 2",
+                "testnick2",
+                Member.Provider.EMAIL,
+                "providerId2",
+                null,
+                null,
+                null
+        );
+        member = memberRepository.save(member);
+
+        // when - 본인(member.getUserId())이 자신의 마이페이지 조회
+        MyPageResponseDto response = memberService.getMyPage(member.getUserId(), member.getUserId());
+
+        // then - isMe가 true임
+        assertThat(response.isMe()).isTrue();
+    }
+}
+


### PR DESCRIPTION

## 🧑‍💻 이번주 주요변경 내용
### [#100] 마이페이지 기능
- Member 엔티티 변경: 프론트 요구사항에 맞게 hobby(취미), bio(한 줄 소개) 필드 추가
- Repository 메서드 추가: PackRepository (findByMemberId, countByMemberId), FeedRepository (findByUserId, countByUserId)
- DTO 생성: MyPageResponseDto, MyPagePackDto, MyPageFeedDto
- 보안 설정 변경: 비로그인 사용자도 프로필을 조회할 수 있도록 SecurityConfig 및 JwtTokenFilter에 마이페이지 경로(GET /api/members/{userId}/mypage) 추가
- Service/Controller 구현: MemberService.getMyPage() 마이페이지 조회 로직 및 해당 엔드포인트 구현

### [#101] 팩 추천 기능
- 팩 추천 알고리즘을 통해 오늘의 추천 스타터 팩 상위 3개를 조회하는 엔드포인트 구현
- 팩(Pack)이 개별 팩 아이템(Pack items)을 포함하고 목록화할 수 있도록 기능 추가
- 추천 계산 및 시간 기반 조회 속도 향상을 위한 데이터베이스 인덱싱 및 쿼리 최적화

### [#102] 해시태그 관리 (백엔드)
- 관리자 페이지 내 해시태그 삽입 기능 추가
- 피드 생성, 수정, 업데이트 시 해시태그 관리 기능 추가 (자동 사용 추적 포함)
- 피드 상세 보기에 모든 연관 해시태그가 표시되도록 개선

### [#103] 해시태그 관리 (프론트엔드)
- 스타터팩 관리자 페이지 프론트엔드에 해시태그 입력 필드 추가
- 해시태그 관리 기능 구현 (최대 10개, 쉼표로 구분, 유효성 검사, 수정 시 기존 태그 자동 완성)

### [#104] 피드 버그 수정
- 피드 상세조회 및 수정이 되지 않던 버그 수정
- 데이터 페칭 효율 향상을 통한 피드 상세조회 성능 최적화

### [#105] 해시태그 NPE 버그 수정 및 리팩토링
- NPE 버그 수정: Feed, Pack 생성 시 해시태그가 null일 때 발생하던 NullPointerException(NPE) 문제 해결 (엔티티 내 null 방어 로직 추가)
- 리팩토링: HashtagService가 null 값을 스스로 처리하도록 캡슐화하고, 관련 메서드의 파라미터 타입을 Set에서 Collection으로 변경
- 버그 수정: Pack 엔티티에 해시태그 정렬을 위한 @OrderBy("tagOrder ASC") 어노테이션 추가

### [#106] 외부 API 연동 리팩토링 (RestClient)
- 메모리 낭비 방지를 위해, 매 요청마다 WebClient를 생성하는 방식에서 싱글톤 RestClient를 사용하도록 리팩토링
- 불필요한 spring-boot-starter-webflux 의존성 제거
- 외부 API(Kakao) 장애 시 무한 대기를 방지하기 위해 타임아웃 설정 추가 (연결: 5초, 읽기: 10초)
- 카카오 API 연동 관련 커스텀 예외 처리 로직 추가 (KakaoAuthException, KakaoServerException)

### [#107] '좋아요/북마크' 경쟁 상태 해결
- 로직 변경: SELECT 후 DELETE 하던 기존 로직을 DELETE를 먼저 시도하는 방식으로 변경하여 경쟁 상태(Race Condition) 문제 해결
- Repository 수정: deleteBy... 쿼리가 삭제된 행의 개수(int)를 반환하도록 수정
- Service 수정: deleteBy...의 반환값(삭제된 행 수)에 따라 '추가(save)' 또는 '취소(decrement)' 로직을 분기 처리
- DTO 리팩터링: of(true) 대신 liked(), unliked() 등 의미가 명확한 정적 팩토리 메서드를 적용하여 가독성 향상
## 코멘트
## 질문

