### PR TITLE
fix: 해시태그 'diff' 로직 분리 및 기존 해시태그 수정 버그 해결

### DIFF
--- a/src/main/java/com/starterpack/feed/entity/FeedHashtag.java
+++ b/src/main/java/com/starterpack/feed/entity/FeedHashtag.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,6 +41,18 @@ public class FeedHashtag {
     public FeedHashtag(Feed feed, Hashtag hashtag, Integer tagOrder) {
         this.feed = feed;
         this.hashtag = hashtag;
+        this.tagOrder = tagOrder;
+    }
+
+    public void updateOrder(List<Hashtag> newHashtags) {
+        int newOrder = newHashtags.indexOf(hashtag);
+
+        if (newOrder != -1) {
+            this.setTagOrder(newOrder);
+        }
+    }
+
+    private void setTagOrder(int tagOrder) {
         this.tagOrder = tagOrder;
     }
 }

--- a/src/main/java/com/starterpack/hashtag/dto/HashtagUpdateResult.java
+++ b/src/main/java/com/starterpack/hashtag/dto/HashtagUpdateResult.java
@@ -8,5 +8,5 @@ public record HashtagUpdateResult(
         Set<Hashtag> added,
         Set<Hashtag> removed
 ){
-    public static final HashtagUpdateResult EMPTY_HASHTAG = new HashtagUpdateResult(Collections.emptySet(), Collections.emptySet());
+    public static final HashtagUpdateResult EMPTY_RESULT = new HashtagUpdateResult(Collections.emptySet(), Collections.emptySet());
 }

--- a/src/main/java/com/starterpack/hashtag/util/HashtagDiffCalculator.java
+++ b/src/main/java/com/starterpack/hashtag/util/HashtagDiffCalculator.java
@@ -1,0 +1,35 @@
+package com.starterpack.hashtag.util;
+
+import com.starterpack.hashtag.dto.HashtagUpdateResult;
+import com.starterpack.hashtag.entity.Hashtag;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class HashtagDiffCalculator {
+    public static HashtagUpdateResult calculateDiff(Collection<Hashtag> oldTags, Collection<Hashtag> newTags) {
+        if (newTags == null || newTags.isEmpty()) {
+            if (oldTags == null || oldTags.isEmpty()) {
+                return HashtagUpdateResult.EMPTY_HASHTAG;
+            }
+
+            return new HashtagUpdateResult(Collections.emptySet(), new HashSet<>(oldTags));
+        }
+
+        if (oldTags == null || oldTags.isEmpty()) {
+            return new HashtagUpdateResult(new HashSet<>(newTags), Collections.emptySet());
+        }
+
+        Set<Hashtag> oldSet = new HashSet<>(oldTags);
+        Set<Hashtag> newSet = new HashSet<>(newTags);
+
+        Set<Hashtag> added = new HashSet<>(newSet);
+        added.removeAll(oldSet);
+
+        Set<Hashtag> removed = new HashSet<>(oldSet);
+        removed.removeAll(newSet);
+
+        return new HashtagUpdateResult(added, removed);
+    }
+}

--- a/src/main/java/com/starterpack/hashtag/util/HashtagDiffCalculator.java
+++ b/src/main/java/com/starterpack/hashtag/util/HashtagDiffCalculator.java
@@ -11,7 +11,7 @@ public class HashtagDiffCalculator {
     public static HashtagUpdateResult calculateDiff(Collection<Hashtag> oldTags, Collection<Hashtag> newTags) {
         if (newTags == null || newTags.isEmpty()) {
             if (oldTags == null || oldTags.isEmpty()) {
-                return HashtagUpdateResult.EMPTY_HASHTAG;
+                return HashtagUpdateResult.EMPTY_RESULT;
             }
 
             return new HashtagUpdateResult(Collections.emptySet(), new HashSet<>(oldTags));

--- a/src/main/java/com/starterpack/pack/entity/Pack.java
+++ b/src/main/java/com/starterpack/pack/entity/Pack.java
@@ -170,7 +170,7 @@ public class Pack {
 
     public HashtagUpdateResult updateHashtag(List<Hashtag> newHashtagList) {
         if (newHashtagList == null) {
-            return HashtagUpdateResult.EMPTY_HASHTAG;
+            return HashtagUpdateResult.EMPTY_RESULT;
         }
 
         Set<Hashtag> oldHashtags = new HashSet<>(this.getHashtags());

--- a/src/main/java/com/starterpack/pack/entity/PackHashtag.java
+++ b/src/main/java/com/starterpack/pack/entity/PackHashtag.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,6 +41,18 @@ public class PackHashtag {
     public PackHashtag(Pack pack, Hashtag hashtag, Integer tagOrder) {
         this.pack = pack;
         this.hashtag = hashtag;
+        this.tagOrder = tagOrder;
+    }
+
+    public void updateOrder(List<Hashtag> newHashtags) {
+        int newOrder = newHashtags.indexOf(hashtag);
+
+        if (newOrder != -1) {
+            this.setTagOrder(newOrder);
+        }
+    }
+
+    private void setTagOrder(int tagOrder) {
         this.tagOrder = tagOrder;
     }
 }


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--feat/login -> dev-->
jihwan38/hashtagRefactor -> develop
### 📄 관련 이슈
<!-- 이슈번호: #334 -->

### 🧑‍💻 구현한 내용
1. 해시태그 Diff 계산 로직 추출
    - 기존 Feed 와 Pack 엔티티의 updateHashtag 메서드 내부에 중복으로 존재하던 diff(added/removed) 계산 로직을 HashtagDiffCalculator 클래스를 만들어 중복을 해결했습니다. 
2. 해시태그 수정 시 `Unique` 제약 조건 위반 버그 해결
### 🧪 테스트 결과

### 👿 트러블 슈팅
해시태그 수정 시 `Unique` 제약 조건 위반 버그
**버그 원인:** 
1. updateHashtag 내부 로직 clear() + add()
    - feed.feedHashtags.clear() 호출
    -> orphanRemoval = true 로 인해 기존 해시태그에 대한 DELETE 쿼리 예약
2. AutoFlush 발동
    - updateHashtag 메서드가 끝난 이후 hashtagService.incrementUsageCount() 호출
    - 해당 메서드는 DB에 UPDATE 쿼리를 날림
    - JPA는 UPDATE 실행 전, DB 동기화를 위해 AutoFlush 강제 실행
3. INSERT 쿼리 실행 및 에러 발생
    - JPA는 Flush를 실행할 때 DELETE 보다 INSERT 쿼리를 보통 먼저 실행
    - 따라서 지워지지 않은 옛날 해시태그가 존재하기에 동일 해시태그가 들어오게 되면 `DataIntegrityViolationException` 에러 발생
   
**해결:**
clear() + add() 로직을 버리고, updateHashtag 메서드 내부 로직을 다음과 같이 '수동 동기화' 방식으로 변경

1. [Remove] HashtagDiffCalculator가 계산한 result.removed()만 removeIf()로 제거

2. [Update] 제거되지 않고 남아있는 existing 항목들은 updateOrder()를 호출해 순서만 업데이트

3. [Add] result.added()에 해당하는 항목만 새로 add() 
### 💬 코멘트





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved hashtag management and ordering system for more consistent behavior across the platform.
  * Enhanced hashtag update processing with better calculation and handling of hashtag additions and removals.
  * Optimized internal hashtag logic for improved reliability and performance when managing hashtag collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->