### PR TITLE
feat: 마이페이지 전용 멤버 정보 수정 api 구현

### DIFF
--- a/src/main/java/com/starterpack/exception/ErrorCode.java
+++ b/src/main/java/com/starterpack/exception/ErrorCode.java
@@ -41,6 +41,9 @@ public enum ErrorCode {
     MEMBER_PROVIDER_ID_DUPLICATED(HttpStatus.CONFLICT,
             "M003",
             "이미 사용 중인 소셜 로그인 계정입니다."),
+    MEMBER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT,
+            "M004",
+            "이미 사용 중인 닉네임입니다."),
     //Security
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED,
             "S001",

--- a/src/main/java/com/starterpack/member/controller/MyPageController.java
+++ b/src/main/java/com/starterpack/member/controller/MyPageController.java
@@ -2,8 +2,11 @@ package com.starterpack.member.controller;
 
 import com.starterpack.auth.login.Login;
 import com.starterpack.member.dto.MyPageResponseDto;
+import com.starterpack.member.dto.MyPageUpdateRequestDto;
 import com.starterpack.member.entity.Member;
 import com.starterpack.member.service.MemberService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -66,6 +69,38 @@ public class MyPageController {
     ) {
         Long currentUserId = (currentMember != null) ? currentMember.getUserId() : null;
         MyPageResponseDto responseDto = memberService.getMyPage(userId, currentUserId);
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
+    @PutMapping("/{userId}/mypage")
+    @Operation(
+            summary = "마이페이지 정보 수정",
+            description = """
+                    마이페이지 정보를 수정합니다.
+                    
+                    **수정 가능한 필드**:
+                    - profileImageUrl: 프로필 사진 URL
+                    - nickname: 닉네임 (중복 불가)
+                    - hobby: 취미
+                    - bio: 한 줄 소개
+                    
+                    **중요**: 
+                    - 빈 값(null 또는 빈 문자열)이 들어온 필드는 수정하지 않습니다.
+                    - 닉네임은 다른 사용자가 사용 중인 경우 수정할 수 없습니다.
+                    """
+    )
+    @SecurityRequirement(name = "Bearer Authentication")
+    public ResponseEntity<MyPageResponseDto> updateMyPage(
+            @PathVariable Long userId,
+            @Login Member currentMember,
+            @Valid @RequestBody MyPageUpdateRequestDto requestDto
+    ) {
+        // 본인만 수정 가능
+        if (!currentMember.getUserId().equals(userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        MyPageResponseDto responseDto = memberService.updateMyPage(userId, requestDto);
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 }

--- a/src/main/java/com/starterpack/member/dto/MyPageUpdateRequestDto.java
+++ b/src/main/java/com/starterpack/member/dto/MyPageUpdateRequestDto.java
@@ -1,0 +1,20 @@
+package com.starterpack.member.dto;
+
+import jakarta.validation.constraints.Size;
+
+// 마이페이지 정보 수정 요청 DTO
+public record MyPageUpdateRequestDto(
+        @Size(max = 500, message = "프로필 이미지 URL은 500자를 초과할 수 없습니다")
+        String profileImageUrl,
+
+        @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다")
+        String nickname,
+
+        @Size(max = 200, message = "취미는 200자를 초과할 수 없습니다")
+        String hobby,
+
+        @Size(max = 500, message = "소개는 500자를 초과할 수 없습니다")
+        String bio
+) {
+}
+


### PR DESCRIPTION
### 📌 PR 타입
-[✅ ] 기능 추가
-[ ] 기능 삭제
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!-- lee-seung-won/modifyUserInfo -> dev-->

### 📄 관련 이슈
<!-- 이슈번호: #334 -->

### 🧑‍💻 구현한 내용
마이페이지에서 정보수정 기능을 위한 api를 구현하였습니다.

기존 멤버 업데이트 컨트롤러는 취미, 한줄소개를 수정하지 않기에
마이페이지 전용 Dto와 컨트롤러를 따로 만들었습니다.

```@PutMapping("/{userId}/mypage")```
### 🧪 테스트 결과

### 👿 트러블 슈팅

### 💬 코멘트





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users can now update their profile information including profile image, nickname, hobby, and bio
* Added validation to prevent duplicate nicknames with appropriate error messaging
* Profile field updates include character length restrictions to maintain data integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->