### PR TITLE
feat: 피드 작성자의 이름을 반환하는 것이 아닌 닉네임을 반환하도록 변경

### DIFF
--- a/src/main/java/com/starterpack/feed/dto/AuthorResponseDto.java
+++ b/src/main/java/com/starterpack/feed/dto/AuthorResponseDto.java
@@ -10,7 +10,7 @@ public record AuthorResponseDto(
         public static AuthorResponseDto from(Member member){
             return new AuthorResponseDto(
                     member.getUserId(),
-                    member.getName(),
+                    member.getNickname(),
                     member.getProfileImageUrl()
             );
         }


### PR DESCRIPTION
### 📌 PR 타입
-[x] 기능 추가
-[ ] 기능 삭제
-[ ] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--feat/login -> dev-->
jihwan38/showNickname
### 📄 관련 이슈
<!-- 이슈번호: #334 -->

### 🧑‍💻 구현한 내용
기존 AuthorResponseDto에서 name을 반환하던 걸 nickname을 반환하도록 변경하였습니다.
### 🧪 테스트 결과

### 👿 트러블 슈팅

### 💬 코멘트





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the author name field in the feed to display nicknames instead of full names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->