### PR TITLE
fix: PERMIT_URL에 댓글 조회 URL 누락 해결

### DIFF
--- a/src/main/java/com/starterpack/config/SecurityConfig.java
+++ b/src/main/java/com/starterpack/config/SecurityConfig.java
@@ -106,6 +106,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET,
                                 "/api/feeds", "/api/feeds/**", // feed 관련 GET 요청
                                 "/api/starterPack/packs", "/api/starterPack/packs/**", "/api/api/starterPack/categories/**", // starterpack 관련 GET 요청
+                                "/api/starterPack/*/comments",
                                 "/api/products", "/api/products/**",
                                 "/api/categories", // 카테고리 조회 GET 요청
                                 "/api/feeds/*/likes",

--- a/src/main/resources/schema-h2.sql
+++ b/src/main/resources/schema-h2.sql
@@ -383,3 +383,32 @@ ALTER TABLE pack_hashtag
             REFERENCES hashtag(id)
             ON DELETE CASCADE
             ON UPDATE CASCADE;
+------------------------------------------------------------
+-- 14) 팩-댓글 연관테이블 (pack_comment)
+------------------------------------------------------------
+CREATE TABLE pack_comment (
+  id          BIGINT NOT NULL AUTO_INCREMENT,
+  pack_id     BIGINT NOT NULL,
+  author_id   BIGINT NOT NULL,
+  content     VARCHAR(500)    NOT NULL,
+  parent_id   BIGINT NULL,
+  depth       INT             NOT NULL DEFAULT 0,
+  is_deleted  BOOLEAN         NOT NULL DEFAULT FALSE,
+  deleted_at  TIMESTAMP       NULL,
+  created_at  TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at  TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  KEY idx_pack_comment_pack (pack_id),
+  KEY idx_pack_comment_author (author_id),
+  KEY idx_pack_comment_parent (parent_id),
+  KEY idx_pack_comment_created_at (created_at),
+  CONSTRAINT fk_pack_comment_pack
+      FOREIGN KEY (pack_id) REFERENCES pack(id)
+          ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT fk_pack_comment_author
+      FOREIGN KEY (author_id) REFERENCES member(user_id)
+          ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT fk_pack_comment_parent
+      FOREIGN KEY (parent_id) REFERENCES pack_comment(id)
+          ON UPDATE CASCADE ON DELETE CASCADE
+);


### PR DESCRIPTION
### 📌 PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--feat/login -> dev-->
jihwan38/permitUrl -> develop
### 📄 관련 이슈
<!-- 이슈번호: #334 -->

### 🧑‍💻 구현한 내용
permit_url에 댓글 조회 URL 이 누락되어 있어 인증이 필요하게 되는 문제를 해결 했습니다. 
### 🧪 테스트 결과

### 👿 트러블 슈팅

### 💬 코멘트





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled public access to starter pack comments
  * Added support for nested, hierarchical comments on starter packs
  * Implemented soft-delete functionality for comments with audit timestamps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->