### PR TITLE
feat: 해시태그 경쟁상태 문제 jdbcTemplate을 이용해 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	testRuntimeOnly 'com.h2database:h2'

--- a/src/main/java/com/starterpack/hashtag/repository/HashtagBulkRepository.java
+++ b/src/main/java/com/starterpack/hashtag/repository/HashtagBulkRepository.java
@@ -1,0 +1,33 @@
+package com.starterpack.hashtag.repository;
+
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class HashtagBulkRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    private static final String Bulk_INSERT_IGNORE_SQL = """
+            INSERT IGNORE INTO hashtag (name, usage_count, created_at, updated_at) 
+            VALUES (?, 0, NOW(), NOW())
+    """;
+
+    @Transactional
+    public void saveAllWithInsertIgnore(Set<String> hashtagNames) {
+        if (hashtagNames == null || hashtagNames.isEmpty()) {
+            return;
+        }
+
+        List<Object[]> batchArgs = hashtagNames.stream()
+                .map(name -> new Object[]{name})
+                .toList();
+
+        jdbcTemplate.batchUpdate(Bulk_INSERT_IGNORE_SQL, batchArgs);
+    }
+
+}


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--feat/login -> dev-->
jihwan38/BulkHashtag -> develop
### 📄 관련 이슈
<!-- 이슈번호: #334 -->

### 🧑‍💻 구현한 내용
1. 문제점 (경쟁 상태)
    - 기존 findOrAddHashtags 메서드는 조회 후 삽입 방식으로 동작
    - 이로 인해 두 개 이상의 요청이 동시에 동일한 새 해시태그를 등록하려 할 때, 두 요청 모두 "태그 없음"으로 판단하고 INSERT를 시도 
    - 이 과정에서 한쪽 요청은 DB의 Unique 제약 조건 위반 에러가 발생하며 롤백되는 문제
2. 해결 (JdbcTemplate 및 INSERT IGNORE 도입)
    - HashtagBulkRepository 신규 생성: JdbcTemplate과 MySQL의 INSERT IGNORE 쿼리를 사용하여 해시태그 이름이 중복될 경우 DB가 알아서 삽입을 무시하는 Bulk Upsert 전용 레포지토리를 구현
    - HashtagService 로직 변경: findOrAddHashtags의 로직을 기존 조회 후 삽입에서 삽입 후 조회 방식으로 변경

    - (삽입) HashtagBulkRepository(JdbcTemplate)가 INSERT IGNORE로 경쟁 상태 없이 안전하게 DB에 태그를 삽입

    - (조회) HashtagRepository(JPA)가 DB에 존재함이 보장된 태그 목록을 findAllByNameIn으로 안전하게 조회
### 🧪 테스트 결과

### 👿 트러블 슈팅

### 💬 코멘트
다들 정말 고생 많으셨습니다...!! 😢 😢 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized bulk hashtag insertion with improved batch processing performance.
  * Enhanced duplicate handling for hashtag creation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->