### PR TITLE
feat: 팩 조회 응답으로 좋아요, 북마크 상태여부 포함하도록 기능 추가 및 마이페이지에서 북마크한 팩도 응답하도록 변경

### DIFF
--- a/src/main/java/com/starterpack/admin/pack/AdminPackController.java
+++ b/src/main/java/com/starterpack/admin/pack/AdminPackController.java
@@ -36,7 +36,7 @@ public class AdminPackController {
     public String listAll(Model model){
         model.addAttribute("categories", categoryService.findAllCategories());
 
-        List<Pack> packList = packService.getPacks();
+        List<Pack> packList = packService.getPacksForAdmin();
         List<PackResponseDto> packs = packList.stream()
                 .map(PackResponseDto::from)
                 .toList();
@@ -50,7 +50,7 @@ public class AdminPackController {
         model.addAttribute("categories", categoryService.findAllCategories());
         model.addAttribute("categoryId", categoryId);
 
-        List<PackResponseDto> packs = packService.getPacksByCategory(categoryId).stream()
+        List<PackResponseDto> packs = packService.getPacksByCategoryForAdmin(categoryId).stream()
                 .map(PackResponseDto::from)
                 .toList();
 
@@ -81,7 +81,7 @@ public class AdminPackController {
         }
 
         Pack created = packService.create(createDto, member);
-        PackDetailResponseDto dto = PackDetailResponseDto.from(created);
+        PackDetailResponseDto dto = PackDetailResponseDto.forAnonymous(created);
 
         redirectAttributes.addFlashAttribute("message", "패키지 '" + dto.name() + "' 등록 완료");
         return "redirect:/admin/packs";
@@ -90,8 +90,8 @@ public class AdminPackController {
     /** 수정 폼 */
     @GetMapping("/{id}/edit")
     public String editForm(@PathVariable Long id, Model model) {
-        Pack pack = packService.getPackDetail(id);
-        PackDetailResponseDto detail = PackDetailResponseDto.from(pack);
+        Pack pack = packService.getPackDetailForAdmin(id);
+        PackDetailResponseDto detail = PackDetailResponseDto.forAnonymous(pack);
 
         // PackItem을 PackItemDto로 변환
         List<PackItemDto> items = detail.items();
@@ -132,9 +132,9 @@ public class AdminPackController {
         }
 
         Pack updated = packService.update(id, updateDto, member);
-        Pack packWithMember = packService.getPackDetail(updated.getId());
+        Pack packWithMember = packService.getPackDetailForAdmin(updated.getId());
 
-        PackDetailResponseDto dto = PackDetailResponseDto.from(packWithMember);
+        PackDetailResponseDto dto = PackDetailResponseDto.forAnonymous(packWithMember);
 
         redirectAttributes.addFlashAttribute("message", "패키지 '" + dto.name() + "' 수정 완료");
         return "redirect:/admin/packs";

--- a/src/main/java/com/starterpack/member/dto/MyPageResponseDto.java
+++ b/src/main/java/com/starterpack/member/dto/MyPageResponseDto.java
@@ -2,6 +2,7 @@ package com.starterpack.member.dto;
 
 import com.starterpack.feed.dto.FeedResponseDto;
 import com.starterpack.member.entity.Member;
+import com.starterpack.pack.dto.PackDetailResponseDto;
 import com.starterpack.pack.entity.Pack;
 import com.starterpack.feed.entity.Feed;
 import java.util.List;
@@ -18,9 +19,10 @@ public record MyPageResponseDto(
         List<MyPagePackDto> packs,
         List<MyPageFeedDto> feeds,
         List<FeedResponseDto> bookmarkedFeeds,
+        List<PackDetailResponseDto> bookmarkedPacks,
         boolean isMe
 ) {
-    public static MyPageResponseDto from(Member member, List<Pack> packs, List<Feed> feeds, boolean isMe, List<FeedResponseDto> bookmarkedFeeds) {
+    public static MyPageResponseDto from(Member member, List<Pack> packs, List<Feed> feeds, boolean isMe, List<FeedResponseDto> bookmarkedFeeds, List<PackDetailResponseDto> bookmarkedPacks) {
         List<MyPagePackDto> packDtos = packs.stream()
                 .map(MyPagePackDto::from)
                 .toList();
@@ -42,6 +44,7 @@ public record MyPageResponseDto(
                 packDtos,
                 feedDtos,
                 bookmarkedFeeds != null ? bookmarkedFeeds : List.of(),
+                bookmarkedPacks != null ? bookmarkedPacks : List.of(),
                 isMe
         );
     }

--- a/src/main/java/com/starterpack/member/service/MemberService.java
+++ b/src/main/java/com/starterpack/member/service/MemberService.java
@@ -9,12 +9,14 @@ import com.starterpack.member.dto.MyPageResponseDto;
 import com.starterpack.member.dto.MyPageUpdateRequestDto;
 import com.starterpack.member.entity.Member;
 import com.starterpack.member.repository.MemberRepository;
+import com.starterpack.pack.dto.PackDetailResponseDto;
 import com.starterpack.pack.entity.Pack;
 import com.starterpack.pack.repository.PackRepository;
 import com.starterpack.feed.entity.Feed;
 import com.starterpack.feed.repository.FeedRepository;
 import com.starterpack.exception.BusinessException;
 import com.starterpack.exception.ErrorCode;
+import com.starterpack.pack.service.PackService;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class MemberService {
     private final PackRepository packRepository;
     private final FeedRepository feedRepository;
     private final FeedService feedService;
+    private final PackService packService;
 
     // 모든 멤버 조회
     public List<Member> findAllMembers() {
@@ -192,12 +195,15 @@ public class MemberService {
         
         // 본인일 때만 북마크한 피드 조회
         List<FeedResponseDto> bookmarkedFeeds = List.of();
+        List<PackDetailResponseDto> bookmarkedPacks = List.of();
         if (isMe && currentMember != null) {
             Pageable pageable = PageRequest.of(0, 10);
             bookmarkedFeeds = feedService.getBookmarkedFeedsByMember(currentMember, pageable).getContent();
+
+            bookmarkedPacks = packService.getBookmarkedPacksByMember(currentMember, pageable).getContent();
         }
 
-        return MyPageResponseDto.from(member, packs, feeds, isMe, bookmarkedFeeds);
+        return MyPageResponseDto.from(member, packs, feeds, isMe, bookmarkedFeeds, bookmarkedPacks);
     }
 
     // 마이페이지 정보 수정
@@ -241,7 +247,8 @@ public class MemberService {
         // updateMyPage는 본인만 호출 가능하므로 북마크한 피드도 조회
         Pageable pageable = PageRequest.of(0, 10);
         List<FeedResponseDto> bookmarkedFeeds = feedService.getBookmarkedFeedsByMember(member, pageable).getContent();
+        List<PackDetailResponseDto> bookmarkedPacks = packService.getBookmarkedPacksByMember(member, pageable).getContent();
 
-        return MyPageResponseDto.from(member, packs, feeds, true, bookmarkedFeeds);
+        return MyPageResponseDto.from(member, packs, feeds, true, bookmarkedFeeds, bookmarkedPacks);
     }
 }

--- a/src/main/java/com/starterpack/pack/controller/PackController.java
+++ b/src/main/java/com/starterpack/pack/controller/PackController.java
@@ -47,31 +47,32 @@ public class PackController {
 
     @GetMapping("/packs")
     @Operation(summary = "스타터팩 목록 조회", description = "모든 스타터팩 목록을 조회합니다.")
-    public Map<String, List<PackDetailResponseDto>> getAllPacks() {
-        List<Pack> packs = packService.getPacks(); // 엔티티 반환
-        List<PackDetailResponseDto> responseDto = packs.stream()
-                .map(PackDetailResponseDto::from)
-                .toList();
+    public Map<String, List<PackDetailResponseDto>> getAllPacks(
+            @Login(required = false) Member member
+    ) {
+        List<PackDetailResponseDto> responseDto = packService.getPacks(member); // 엔티티 반환
+
         return Map.of("packs", responseDto);
     }
 
     @GetMapping("/categories/{categoryId}/packs")
     @Operation(summary = "카테고리별 스타터팩 조회", description = "특정 카테고리의 스타터팩 목록을 조회합니다.")
     public Map<String, List<PackDetailResponseDto>> listByCategory(
-            @PathVariable @Positive Long categoryId
+            @PathVariable @Positive Long categoryId,
+            @Login(required = false) Member member
     ) {
-        List<Pack> packs = packService.getPacksByCategory(categoryId); // 엔티티 반환
-        List<PackDetailResponseDto> responseDto = packs.stream()
-                .map(PackDetailResponseDto::from)
-                .toList();
+        List<PackDetailResponseDto> responseDto = packService.getPacksByCategory(categoryId, member); // 엔티티 반환
+
         return Map.of("packs", responseDto);
     }
 
     @GetMapping("/packs/{id}")
     @Operation(summary = "스타터팩 상세 조회", description = "특정 스타터팩의 상세 정보를 조회합니다.")
-    public PackDetailResponseDto detail(@PathVariable @Positive Long id) {
-        Pack pack = packService.getPackDetail(id); // 엔티티 반환
-        return PackDetailResponseDto.from(pack);
+    public PackDetailResponseDto detail(
+            @PathVariable @Positive Long id,
+            @Login(required = false) Member member) {
+        PackDetailResponseDto response = packService.getPackDetail(id, member); // 엔티티 반환
+        return response;
     }
 
     @PostMapping("/packs")
@@ -82,7 +83,7 @@ public class PackController {
             @Login Member member
     ) {
         Pack created = packService.create(req, member); // 엔티티 반환
-        PackDetailResponseDto body = PackDetailResponseDto.from(created);
+        PackDetailResponseDto body = PackDetailResponseDto.forAnonymous(created);
         return ResponseEntity
                 .created(URI.create("/api/starterPack/packs/" + body.id())) // base path 정합성
                 .body(body);
@@ -97,8 +98,7 @@ public class PackController {
             @Login Member member
     ) {
         packService.update(id, req, member);
-        Pack pack = packService.getPackDetail(id);
-        PackDetailResponseDto response = PackDetailResponseDto.from(pack);
+        PackDetailResponseDto response = packService.getPackDetail(id, member);;
 
         return ResponseEntity.ok(response);
 

--- a/src/main/java/com/starterpack/pack/dto/InteractionStatusResponseDto.java
+++ b/src/main/java/com/starterpack/pack/dto/InteractionStatusResponseDto.java
@@ -1,0 +1,19 @@
+package com.starterpack.pack.dto;
+
+public record InteractionStatusResponseDto(
+        Boolean isLiked,
+        Boolean isBookmarked
+) {
+
+    private static final InteractionStatusResponseDto ANONYMOUS_STATUS = new InteractionStatusResponseDto(
+            false, false);
+
+    public static InteractionStatusResponseDto anonymousStatus() {
+        return ANONYMOUS_STATUS;
+    }
+
+    public static InteractionStatusResponseDto of(Boolean isLiked,
+            Boolean isBookmarked) {
+        return new InteractionStatusResponseDto(isLiked, isBookmarked);
+    }
+}

--- a/src/main/java/com/starterpack/pack/dto/PackDetailResponseDto.java
+++ b/src/main/java/com/starterpack/pack/dto/PackDetailResponseDto.java
@@ -18,14 +18,11 @@ public record PackDetailResponseDto(
         Integer bookmarkCount,
         Integer commentCount,
         String authorNickname,
-        Long memberId
+        Long memberId,
+        InteractionStatusResponseDto interactionStatusResponseDto
 ) {
-    public static PackDetailResponseDto from(Pack pack) {
-        List<PackItemDto> items = pack.getItems().stream()
-                .map(PackItemDto::from)
-                .toList();
-
-        return new PackDetailResponseDto(
+    public PackDetailResponseDto(Pack pack, InteractionStatusResponseDto status) {
+        this(
                 pack.getId(),
                 pack.getName(),
                 pack.getPrice(),
@@ -33,7 +30,9 @@ public record PackDetailResponseDto(
                 pack.getMainImageUrl(),
                 pack.getCategory().getId(),
                 pack.getCategory().getName(),
-                items,
+                pack.getItems().stream() 
+                        .map(PackItemDto::from)
+                        .toList(),
                 pack.getHashtags().stream()
                         .map(HashtagResponseDto::from)
                         .toList(),
@@ -41,7 +40,16 @@ public record PackDetailResponseDto(
                 pack.getPackBookmarkCount(),
                 pack.getPackCommentCount(),
                 pack.getMember().getNickname(),
-                pack.getMember().getUserId()
+                pack.getMember().getUserId(),
+                status
         );
+    }
+
+    public static PackDetailResponseDto forAnonymous(Pack pack) {
+        return new PackDetailResponseDto(pack, InteractionStatusResponseDto.anonymousStatus());
+    }
+
+    public static PackDetailResponseDto forMember(Pack pack, InteractionStatusResponseDto status) {
+        return new PackDetailResponseDto(pack, status);
     }
 }

--- a/src/main/java/com/starterpack/pack/entity/Pack.java
+++ b/src/main/java/com/starterpack/pack/entity/Pack.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter
@@ -56,10 +57,11 @@ public class Pack {
     @Column(name = "description")
     private String description;
 
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "pack", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PackItem> items = new ArrayList<>();
 
-    @org.hibernate.annotations.BatchSize(size = 100)
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "pack", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("tagOrder ASC")
     private List<PackHashtag> packHashtags = new ArrayList<>();

--- a/src/main/java/com/starterpack/pack/entity/PackBookmark.java
+++ b/src/main/java/com/starterpack/pack/entity/PackBookmark.java
@@ -12,9 +12,11 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
+@Getter
 @Table(name = "pack_bookmark", uniqueConstraints = {
         @UniqueConstraint(
                 name = "uk_pack_bookmark_member",

--- a/src/main/java/com/starterpack/pack/repository/PackBookmarkRepository.java
+++ b/src/main/java/com/starterpack/pack/repository/PackBookmarkRepository.java
@@ -3,9 +3,16 @@ package com.starterpack.pack.repository;
 import com.starterpack.member.entity.Member;
 import com.starterpack.pack.entity.Pack;
 import com.starterpack.pack.entity.PackBookmark;
+import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PackBookmarkRepository extends JpaRepository<PackBookmark, Long> {
     boolean existsByPackAndMember(Pack pack, Member member);
     int deleteByPackAndMember(Pack pack, Member member);
+
+    @Query("SELECT pb.pack.id FROM PackBookmark pb WHERE pb.member = :member AND pb.pack.id IN :packIds")
+    Set<Long> findPackIdsByMemberAndPackIds(@Param("member") Member member, @Param("packIds") List<Long> packIds);
 }

--- a/src/main/java/com/starterpack/pack/repository/PackBookmarkRepository.java
+++ b/src/main/java/com/starterpack/pack/repository/PackBookmarkRepository.java
@@ -5,6 +5,8 @@ import com.starterpack.pack.entity.Pack;
 import com.starterpack.pack.entity.PackBookmark;
 import java.util.List;
 import java.util.Set;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,4 +17,6 @@ public interface PackBookmarkRepository extends JpaRepository<PackBookmark, Long
 
     @Query("SELECT pb.pack.id FROM PackBookmark pb WHERE pb.member = :member AND pb.pack.id IN :packIds")
     Set<Long> findPackIdsByMemberAndPackIds(@Param("member") Member member, @Param("packIds") List<Long> packIds);
+
+    Page<PackBookmark> findByMemberOrderByCreatedAtDesc(@Param("member") Member member, Pageable pageable);
 }

--- a/src/main/java/com/starterpack/pack/repository/PackLikeRepository.java
+++ b/src/main/java/com/starterpack/pack/repository/PackLikeRepository.java
@@ -3,6 +3,8 @@ package com.starterpack.pack.repository;
 import com.starterpack.member.entity.Member;
 import com.starterpack.pack.entity.Pack;
 import com.starterpack.pack.entity.PackLike;
+import java.util.List;
+import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +18,7 @@ public interface PackLikeRepository extends JpaRepository<PackLike, Long> {
 
     @Query("SELECT pl FROM PackLike pl JOIN FETCH  pl.member WHERE pl.pack = :pack")
     Page<PackLike> findByPack(@Param("pack") Pack pack, Pageable pageable);
+
+    @Query("SELECT pl.pack.id FROM PackLike pl WHERE pl.member = :member AND pl.pack.id IN :packIds")
+    Set<Long> findPackIdsByMemberAndPackIds(@Param("member") Member member, @Param("packIds") List<Long> packIds);
 }

--- a/src/main/java/com/starterpack/pack/service/PackService.java
+++ b/src/main/java/com/starterpack/pack/service/PackService.java
@@ -300,6 +300,10 @@ public class PackService {
     }
 
     private List<PackDetailResponseDto> convertPacksToDto(List<Pack> packs, Member member) {
+        if (packs.isEmpty()) {
+            return List.of();
+        }
+
         if (member == null) {
             return packs.stream()
                     .map(PackDetailResponseDto::forAnonymous)


### PR DESCRIPTION
### 📌 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### ✈️ 반영 브랜치
<!--feat/login -> dev-->
jihwan38/mypagePackBookmark
### 📄 관련 이슈
<!-- 이슈번호: #334 -->

### 🧑‍💻 구현한 내용
1. 팩 API 리팩토링 (Feed 모듈과 동일하게 수정)
    - `PackController`의 `GET` API(`detail`, `packs`, `categories/{id}/packs`)에 `@Login(required = false)`를 적용
    - `PackService`가 `Member` 객체를 받아, 로그인/비로그인 상태에 따라 `forMember` 또는 `forAnonymous` DTO를 반환하도록 수정
2. 마이페이지 기능 추가
    - `MemberService`(`getMyPage` 등)에 `PackService`를 연동하여 '북마크한 팩' 목록이 포함되도록 수정

### 🧪 테스트 결과

### 👿 트러블 슈팅
### 💬 코멘트





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bookmarked packs appear on user profile with paginated browsing.
  * Pack responses show interaction status (liked/bookmarked) per user.
  * Pack detail/list views are personalized when signed in; anonymous views preserved.

* **Improvements**
  * Admin pack retrieval uses dedicated admin paths for clearer admin results.
  * Repository and model changes support efficient bookmark/like lookups and batch fetching.
* **Refactor**
  * DTOs updated to surface interaction state consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->